### PR TITLE
Replace usage of `getConnectionRef()` with `getConnection()`

### DIFF
--- a/includes/ImportDumpRequestManager.php
+++ b/includes/ImportDumpRequestManager.php
@@ -104,9 +104,9 @@ class ImportDumpRequestManager {
 		if ( $centralWiki ) {
 			$this->dbw = $this->dbLoadBalancerFactory->getMainLB(
 				$centralWiki
-			)->getConnectionRef( DB_PRIMARY, [], $centralWiki );
+			)->getConnection( DB_PRIMARY, [], $centralWiki );
 		} else {
-			$this->dbw = $this->dbLoadBalancerFactory->getMainLB()->getConnectionRef( DB_PRIMARY );
+			$this->dbw = $this->dbLoadBalancerFactory->getMainLB()->getConnection( DB_PRIMARY );
 		}
 
 		$this->row = $this->dbw->selectRow(
@@ -271,7 +271,7 @@ class ImportDumpRequestManager {
 
 		$dbr = $this->dbLoadBalancerFactory->getMainLB(
 			$this->getTarget()
-		)->getConnectionRef( DB_REPLICA, [], $this->getTarget() );
+		)->getConnection( DB_REPLICA, [], $this->getTarget() );
 
 		$row = $dbr->selectRow(
 			'interwiki',
@@ -294,7 +294,7 @@ class ImportDumpRequestManager {
 		) {
 			$dbr = $this->dbLoadBalancerFactory->getMainLB(
 				$this->config->get( 'InterwikiCentralDB' )
-			)->getConnectionRef( DB_REPLICA, [], $this->config->get( 'InterwikiCentralDB' ) );
+			)->getConnection( DB_REPLICA, [], $this->config->get( 'InterwikiCentralDB' ) );
 
 			$row = $dbr->selectRow(
 				'interwiki',

--- a/includes/ImportDumpRequestQueuePager.php
+++ b/includes/ImportDumpRequestQueuePager.php
@@ -53,9 +53,9 @@ class ImportDumpRequestQueuePager extends TablePager {
 		if ( $centralWiki ) {
 			$this->mDb = $dbLoadBalancerFactory->getMainLB(
 				$centralWiki
-			)->getConnectionRef( DB_REPLICA, [], $centralWiki );
+			)->getConnection( DB_REPLICA, [], $centralWiki );
 		} else {
-			$this->mDb = $dbLoadBalancerFactory->getMainLB()->getConnectionRef( DB_REPLICA );
+			$this->mDb = $dbLoadBalancerFactory->getMainLB()->getConnection( DB_REPLICA );
 		}
 
 		$this->linkRenderer = $linkRenderer;

--- a/includes/Specials/SpecialRequestImportDump.php
+++ b/includes/Specials/SpecialRequestImportDump.php
@@ -192,9 +192,9 @@ class SpecialRequestImportDump extends FormSpecialPage {
 		if ( $centralWiki ) {
 			$dbw = $this->dbLoadBalancerFactory->getMainLB(
 				$centralWiki
-			)->getConnectionRef( DB_PRIMARY, [], $centralWiki );
+			)->getConnection( DB_PRIMARY, [], $centralWiki );
 		} else {
-			$dbw = $this->dbLoadBalancerFactory->getMainLB()->getConnectionRef( DB_PRIMARY );
+			$dbw = $this->dbLoadBalancerFactory->getMainLB()->getConnection( DB_PRIMARY );
 		}
 
 		$duplicate = $dbw->selectRow(


### PR DESCRIPTION
`ILoadBalancer::getConnectionRef()` is deprecated with 1.39.