### PR TITLE
Add RateLimits default

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -174,6 +174,14 @@
 		"echo-subscriptions-email-importdump-new-request",
 		"echo-subscriptions-web-importdump-new-request"
 	],
+	"RateLimits": {
+		"request-import-dump": {
+			"user": [
+				5,
+				60
+			]
+		}
+	},
 	"ServiceWiringFiles": [
 		"includes/ServiceWiring.php"
 	],

--- a/includes/Specials/SpecialRequestImportDump.php
+++ b/includes/Specials/SpecialRequestImportDump.php
@@ -185,7 +185,7 @@ class SpecialRequestImportDump extends FormSpecialPage {
 		}
 
 		if (
-			$this->getUser()->pingLimiter( 'requestimportdump' ) ||
+			$this->getUser()->pingLimiter( 'request-import-dump' ) ||
 			UploadBase::isThrottled( $this->getUser() )
 		) {
 			return Status::newFatal( 'actionthrottledtext' );


### PR DESCRIPTION
Limit to 5 requests per 60 seconds. Multiple requests may be necessary for users, but limit it to prevent excessive spam.