### PR TITLE
Notifications: use primary link instead of secondary links

### DIFF
--- a/includes/Notifications/EchoNewRequestPresentationModel.php
+++ b/includes/Notifications/EchoNewRequestPresentationModel.php
@@ -42,22 +42,13 @@ class EchoNewRequestPresentationModel extends EchoEventPresentationModel {
 	}
 
 	/**
-	 * @return bool
-	 */
-	public function getPrimaryLink() {
-		return false;
-	}
-
-	/**
 	 * @return array
 	 */
-	public function getSecondaryLinks() {
-		$visitLink = [
+	public function getPrimaryLink() {
+		return [
 			'url' => $this->event->getExtraParam( 'request-url', 0 ),
 			'label' => $this->msg( 'importdump-notification-visit-request' )->text(),
 			'prioritized' => true,
 		];
-
-		return [ $visitLink ];
 	}
 }

--- a/includes/Notifications/EchoRequestCommentPresentationModel.php
+++ b/includes/Notifications/EchoRequestCommentPresentationModel.php
@@ -37,22 +37,13 @@ class EchoRequestCommentPresentationModel extends EchoEventPresentationModel {
 	}
 
 	/**
-	 * @return bool
-	 */
-	public function getPrimaryLink() {
-		return false;
-	}
-
-	/**
 	 * @return array
 	 */
-	public function getSecondaryLinks() {
-		$visitLink = [
+	public function getPrimaryLink() {
+		return [
 			'url' => $this->event->getExtraParam( 'request-url', 0 ),
 			'label' => $this->msg( 'importdump-notification-visit-request' )->text(),
 			'prioritized' => true,
 		];
-
-		return [ $visitLink ];
 	}
 }

--- a/includes/Notifications/EchoRequestStatusUpdatePresentationModel.php
+++ b/includes/Notifications/EchoRequestStatusUpdatePresentationModel.php
@@ -35,22 +35,13 @@ class EchoRequestStatusUpdatePresentationModel extends EchoEventPresentationMode
 	}
 
 	/**
-	 * @return bool
-	 */
-	public function getPrimaryLink() {
-		return false;
-	}
-
-	/**
 	 * @return array
 	 */
-	public function getSecondaryLinks() {
-		$visitLink = [
+	public function getPrimaryLink() {
+		return [
 			'url' => $this->event->getExtraParam( 'request-url', 0 ),
 			'label' => $this->msg( 'importdump-notification-visit-request' )->text(),
 			'prioritized' => true,
 		];
-
-		return [ $visitLink ];
 	}
 }


### PR DESCRIPTION
Per `PHP Notice: Trying to access array offset on value of type bool`:
https://github.com/wikimedia/mediawiki-extensions-Echo/blob/0a7c3d0/includes/formatters/EchoPlainTextEmailFormatter.php#L20, which is required, whereas https://github.com/wikimedia/mediawiki-extensions-Echo/blob/0a7c3d0/includes/formatters/EchoPlainTextEmailFormatter.php#L24 does the same thing with multiple, but is by default, an empty array (https://github.com/wikimedia/mediawiki-extensions-Echo/blob/0a7c3d0/includes/formatters/EventPresentationModel.php#L522), so does nothing.