### PR TITLE
Add seperate error message for private requests

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -77,6 +77,7 @@
 	"importdump-notification-header-status-update": "Status updated for import dump request #$1",
 	"importdump-notification-visit-request": "Visit request",
 	"importdump-notloggedin": "Sorry, you need to <span class=\"plainlinks\">[$1 log in]</span> before you can request an import dump.",
+	"importdump-private-request": "You do not have permission to view this request as it is marked as private.",
 	"importdump-request-edited": "Request edited by $1.\n\n[Changes made]$2",
 	"importdump-request-edited-reason": "\nReason:\nPrevious value: $1\nNew value: $2",
 	"importdump-request-edited-source": "\nSource:\nPrevious value: $1\nNew value: $2",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -77,7 +77,7 @@
 	"importdump-notification-header-status-update": "Status updated for import dump request #$1",
 	"importdump-notification-visit-request": "Visit request",
 	"importdump-notloggedin": "Sorry, you need to <span class=\"plainlinks\">[$1 log in]</span> before you can request an import dump.",
-	"importdump-private-request": "You do not have permission to view this request as it is marked as private.",
+	"importdump-private": "You do not have permission to view this request as it is marked as private.",
 	"importdump-request-edited": "Request edited by $1.\n\n[Changes made]$2",
 	"importdump-request-edited-reason": "\nReason:\nPrevious value: $1\nNew value: $2",
 	"importdump-request-edited-source": "\nSource:\nPrevious value: $1\nNew value: $2",

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -80,6 +80,7 @@
 	"importdump-notification-header-status-update": "Echo notification header for 'importdump-request-status-update'. $1 is the request ID.",
 	"importdump-notification-visit-request": "Echo notification 'Visit request' label.",
 	"importdump-notloggedin": "Error message if user tries to request an import dump while not being logged in.",
+	"importdump-private-request": "Error message if a user tries to view an import dump request that is marked as private and they do not have access to it.",
 	"importdump-request-edited": "'Request edited' message. $1 is the actor's username; $2 is the changes that were made.",
 	"importdump-request-edited-reason": "Message displayed if the value of 'reason' was edited. $1 is the previous value; $2 is the new value.",
 	"importdump-request-edited-source": "Message displayed if the value of 'source' was edited. $1 is the previous value; $2 is the new value.",

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -80,7 +80,7 @@
 	"importdump-notification-header-status-update": "Echo notification header for 'importdump-request-status-update'. $1 is the request ID.",
 	"importdump-notification-visit-request": "Echo notification 'Visit request' label.",
 	"importdump-notloggedin": "Error message if user tries to request an import dump while not being logged in.",
-	"importdump-private-request": "Error message if a user tries to view an import dump request that is marked as private and they do not have access to it.",
+	"importdump-private": "Error message if a user tries to view an import dump request that is marked as private and they do not have access to it.",
 	"importdump-request-edited": "'Request edited' message. $1 is the actor's username; $2 is the changes that were made.",
 	"importdump-request-edited-reason": "Message displayed if the value of 'reason' was edited. $1 is the previous value; $2 is the new value.",
 	"importdump-request-edited-source": "Message displayed if the value of 'source' was edited. $1 is the previous value; $2 is the new value.",

--- a/includes/ImportDumpRequestViewer.php
+++ b/includes/ImportDumpRequestViewer.php
@@ -57,7 +57,7 @@ class ImportDumpRequestViewer {
 			!$this->permissionManager->userHasRight( $user, 'view-private-import-dump-requests' )
 		) {
 			$this->context->getOutput()->addHTML(
-				Html::errorBox( $this->context->msg( 'importdump-unknown' )->escaped() )
+				Html::errorBox( $this->context->msg( 'importdump-private' )->escaped() )
 			);
 
 			return [];


### PR DESCRIPTION
Rather than using `importdump-unknown` which may be confusing in this context.