### PR TITLE
Fix file verification in upload form

### DIFF
--- a/includes/Specials/SpecialRequestImportDump.php
+++ b/includes/Specials/SpecialRequestImportDump.php
@@ -126,7 +126,6 @@ class SpecialRequestImportDump extends FormSpecialPage {
 					'help-message' => 'importdump-help-upload-file',
 					'hide-if' => [ '!==', 'wpUploadSourceType', 'File' ],
 					'accept' => [ '.xml' ],
-					'required' => true,
 				],
 				'UploadFileURL' => [
 					'type' => 'url',
@@ -143,7 +142,6 @@ class SpecialRequestImportDump extends FormSpecialPage {
 					'label-message' => 'importdump-label-upload-file',
 					'help-message' => 'importdump-help-upload-file',
 					'accept' => [ '.xml' ],
-					'required' => true,
 				],
 			];
 		}
@@ -221,9 +219,8 @@ class SpecialRequestImportDump extends FormSpecialPage {
 			return User::newFatalPermissionDeniedStatus( $permission );
 		}
 
-		$status = $uploadBase->fetchFile();
-		if ( !$status->isOK() ) {
-			return $status;
+		if ( $uploadBase->isEmptyFile() ) {
+			return Status::newFatal( 'empty-file' );
 		}
 
 		$virus = UploadBase::detectVirus( $uploadBase->getTempPath() );


### PR DESCRIPTION
File form components can't be required (explicitly in the form) due to
some upstream weirdness.
Instead we'll have to check to see if the file is empty when processing
the form in onSubmit.
UploadBase::fetchFile() is a no-op (it doesn't do anything, so we can
replace it with our isEmptyFile check.