### PR TITLE
Use request-import for RateLimits

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -218,7 +218,7 @@
 		"echo-subscriptions-web-importdump-request-status-update": true
 	},
 	"RateLimits": {
-		"request-import-dump": {
+		"request-import": {
 			"user": [
 				5,
 				60

--- a/includes/Specials/SpecialRequestImportDump.php
+++ b/includes/Specials/SpecialRequestImportDump.php
@@ -190,7 +190,7 @@ class SpecialRequestImportDump extends FormSpecialPage
 		}
 
 		if (
-			$this->getUser()->pingLimiter( 'request-import-dump' ) ||
+			$this->getUser()->pingLimiter( 'request-import' ) ||
 			$this->getUser()->pingLimiter( 'upload' )
 		) {
 			return Status::newFatal( 'actionthrottledtext' );


### PR DESCRIPTION
In preparation for renaming ImportDump to RequestImport for a better name to later expand supported import options (such as ImportImages)