### PR TITLE
Rename import-dump rights

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -47,14 +47,14 @@
 	},
 	"GroupPermissions": {
 		"user": {
-			"request-import-dump": true
+			"request-import": true
 		}
 	},
 	"AvailableRights": [
-		"handle-import-dump-interwiki",
-		"handle-import-dump-requests",
-		"request-import-dump",
-		"view-private-import-dump-requests"
+		"handle-import-interwiki",
+		"handle-import-requests",
+		"request-import",
+		"view-private-import-requests"
 	],
 	"LogActionsHandlers": {
 		"importdump/*": "LogFormatter",
@@ -73,7 +73,7 @@
 		"importdumpprivate"
 	],
 	"LogRestrictions": {
-		"importdumpprivate": "view-private-import-dump-requests"
+		"importdumpprivate": "view-private-import-requests"
 	},
 	"ActionFilteredLogs": {
 		"importdump": {

--- a/extension.json
+++ b/extension.json
@@ -51,7 +51,7 @@
 		}
 	},
 	"AvailableRights": [
-		"handle-import-interwiki",
+		"handle-import-request-interwiki",
 		"handle-import-requests",
 		"request-import",
 		"view-private-import-requests"

--- a/i18n/ar.json
+++ b/i18n/ar.json
@@ -6,7 +6,7 @@
 			"محمد أحمد عبد الفتاح"
 		]
 	},
-	"action-view-private-import-dump-requests": "عرض طلبات التفريغ الخاصة بالاستيراد",
+	"action-view-private-import-requests": "عرض طلبات التفريغ الخاصة بالاستيراد",
 	"echo-category-title-importdump-new-request": "طلب تفريغ استيراد جديد",
 	"echo-category-title-importdump-request-comment": "تمت إضافة التعليق إلى طلب تفريغ الاستيراد",
 	"importdump-comment-given": "تم تقديم التعليق بواسطة $1:",
@@ -58,8 +58,8 @@
 	"importdump-unknown": "طلب غير معروف.",
 	"importdump-usergroups-none": "لا شيء",
 	"importdumpprivate-log-header": "هذا سجل لجميع طلبات تفريغ الاستيراد وتحديثات الحالة للطلبات ذات الأهداف التي تمثل مواقع ويكى الخاصة.",
-	"ipb-action-request-import-dump": "طلب استيراد تفريغ",
+	"ipb-action-request-import": "طلب استيراد تفريغ",
 	"log-action-filter-importdumpprivate": "نوع الفعل:",
 	"logentry-importdumpprivate-request": "طلب $1 تفريغ استيراد لـويكى الخاص $4 في $5.",
-	"right-handle-import-dump-requests": "التعامل مع طلبات تفريغ استيراد المستخدم"
+	"right-handle-import-requests": "التعامل مع طلبات تفريغ استيراد المستخدم"
 }

--- a/i18n/de.json
+++ b/i18n/de.json
@@ -7,7 +7,7 @@
 			"Sebastian Wallroth"
 		]
 	},
-	"action-handle-import-interwiki": "Import-Dump-Interwiki bearbeiten",
+	"action-handle-import-request-interwiki": "Import-Dump-Interwiki bearbeiten",
 	"action-handle-import-requests": "Benutzerimportanfragen bearbeiten",
 	"action-request-import": "Importe anfordern",
 	"action-view-private-import-requests": "private Importanträge anzeigen",
@@ -121,7 +121,7 @@
 	"logentry-importdumpprivate-statusupdate": "$1 hat den Status der privaten Import-Dump-Anfrage $4 auf '$5' aktualisiert.",
 	"requestimportdump": "Import anfordern",
 	"requestimportdumpqueue": "Warteschlange für Importanträge",
-	"right-handle-import-interwiki": "Import-Dump interwiki bearbeiten",
+	"right-handle-import-request-interwiki": "Import-Dump interwiki bearbeiten",
 	"right-handle-import-requests": "Bearbeitung von Benutzer-Import-Dump-Anfragen",
 	"right-request-import": "Importe anfordern",
 	"right-view-private-import-requests": "Private Importanträge anzeigen"

--- a/i18n/de.json
+++ b/i18n/de.json
@@ -7,10 +7,10 @@
 			"Sebastian Wallroth"
 		]
 	},
-	"action-handle-import-dump-interwiki": "Import-Dump-Interwiki bearbeiten",
-	"action-handle-import-dump-requests": "Benutzerimportanfragen bearbeiten",
-	"action-request-import-dump": "Importe anfordern",
-	"action-view-private-import-dump-requests": "private Importanträge anzeigen",
+	"action-handle-import-interwiki": "Import-Dump-Interwiki bearbeiten",
+	"action-handle-import-requests": "Benutzerimportanfragen bearbeiten",
+	"action-request-import": "Importe anfordern",
+	"action-view-private-import-requests": "private Importanträge anzeigen",
 	"echo-category-title-importdump-new-request": "Neuer Antrag auf Import-Dump",
 	"echo-category-title-importdump-request-comment": "Kommentar zu einer Import-Dump-Anfrage hinzugefügt",
 	"echo-category-title-importdump-request-status-update": "Status für eine Import-Dump-Anfrage aktualisiert",
@@ -104,7 +104,7 @@
 	"importdump-usergroups-none": "keine",
 	"importdumpprivate-log-header": "Dies ist ein Protokoll aller Importanfragen und Statusaktualisierungen für Anfragen mit Zielen, die private Wikis sind.",
 	"importdumpprivate-log-name": "Anfragen importieren Privates Protokoll",
-	"ipb-action-request-import-dump": "Importe beantragen",
+	"ipb-action-request-import": "Importe beantragen",
 	"log-action-filter-importdump": "Typ der Aktion:",
 	"log-action-filter-importdump-interwiki": "Änderungen der Interwiki-Tabelle",
 	"log-action-filter-importdump-request": "Neue Anfragen eingereicht",
@@ -121,8 +121,8 @@
 	"logentry-importdumpprivate-statusupdate": "$1 hat den Status der privaten Import-Dump-Anfrage $4 auf '$5' aktualisiert.",
 	"requestimportdump": "Import anfordern",
 	"requestimportdumpqueue": "Warteschlange für Importanträge",
-	"right-handle-import-dump-interwiki": "Import-Dump interwiki bearbeiten",
-	"right-handle-import-dump-requests": "Bearbeitung von Benutzer-Import-Dump-Anfragen",
-	"right-request-import-dump": "Importe anfordern",
-	"right-view-private-import-dump-requests": "Private Importanträge anzeigen"
+	"right-handle-import-interwiki": "Import-Dump interwiki bearbeiten",
+	"right-handle-import-requests": "Bearbeitung von Benutzer-Import-Dump-Anfragen",
+	"right-request-import": "Importe anfordern",
+	"right-view-private-import-requests": "Private Importanträge anzeigen"
 }

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -4,7 +4,7 @@
 			"Universal Omega"
 		]
 	},
-	"action-handle-import-interwiki": "handle remote interwiki prefixes for import requests",
+	"action-handle-import-request-interwiki": "handle remote interwiki prefixes for import requests",
 	"action-handle-import-requests": "handle user import requests",
 	"action-request-import": "request imports",
 	"action-view-private-import-requests": "view private import requests",
@@ -134,7 +134,7 @@
 	"requestimportdumpqueue": "Import requests queue",
 	"requestimportdumpqueue-header": "Search import requests",
 	"requestimportdumpqueue-header-info": "You can use this form to search through import requests. Use the parameters below to refine your search.",
-	"right-handle-import-interwiki": "Handle remote interwiki prefixes for import requests",
+	"right-handle-import-request-interwiki": "Handle remote interwiki prefixes for import requests",
 	"right-handle-import-requests": "Handle user import requests",
 	"right-request-import": "Request imports",
 	"right-view-private-import-requests": "View private import requests"

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -4,10 +4,10 @@
 			"Universal Omega"
 		]
 	},
-	"action-handle-import-dump-interwiki": "handle remote interwiki prefixes for import requests",
-	"action-handle-import-dump-requests": "handle user import requests",
-	"action-request-import-dump": "request imports",
-	"action-view-private-import-dump-requests": "view private import requests",
+	"action-handle-import-interwiki": "handle remote interwiki prefixes for import requests",
+	"action-handle-import-requests": "handle user import requests",
+	"action-request-import": "request imports",
+	"action-view-private-import-requests": "view private import requests",
 	"echo-category-title-importdump-import-failed": "Import request failed",
 	"echo-category-title-importdump-new-request": "New import request",
 	"echo-category-title-importdump-request-comment": "Comment added to an import request",
@@ -111,7 +111,7 @@
 	"importdump-usergroups-none": "none",
 	"importdumpprivate-log-header": "This is a log of all import requests and status updates for requests with targets that are private wikis.",
 	"importdumpprivate-log-name": "Import requests private log",
-	"ipb-action-request-import-dump": "Requesting imports",
+	"ipb-action-request-import": "Requesting imports",
 	"log-action-filter-importdump": "Type of action:",
 	"log-action-filter-importdump-interwiki": "Interwiki table modifications",
 	"log-action-filter-importdump-request": "New requests submitted",
@@ -134,8 +134,8 @@
 	"requestimportdumpqueue": "Import requests queue",
 	"requestimportdumpqueue-header": "Search import requests",
 	"requestimportdumpqueue-header-info": "You can use this form to search through import requests. Use the parameters below to refine your search.",
-	"right-handle-import-dump-interwiki": "Handle remote interwiki prefixes for import requests",
-	"right-handle-import-dump-requests": "Handle user import requests",
-	"right-request-import-dump": "Request imports",
-	"right-view-private-import-dump-requests": "View private import requests"
+	"right-handle-import-interwiki": "Handle remote interwiki prefixes for import requests",
+	"right-handle-import-requests": "Handle user import requests",
+	"right-request-import": "Request imports",
+	"right-view-private-import-requests": "View private import requests"
 }

--- a/i18n/es.json
+++ b/i18n/es.json
@@ -9,10 +9,10 @@
 			"OriginReboot"
 		]
 	},
-	"action-handle-import-dump-interwiki": "manejar volcado de importación interwiki",
-	"action-handle-import-dump-requests": "manejar solicitudes de volcado de importación de usuarios",
-	"action-request-import-dump": "solicitar volcados de importación",
-	"action-view-private-import-dump-requests": "ver solicitudes de volcado de importación privadas",
+	"action-handle-import-interwiki": "manejar volcado de importación interwiki",
+	"action-handle-import-requests": "manejar solicitudes de volcado de importación de usuarios",
+	"action-request-import": "solicitar volcados de importación",
+	"action-view-private-import-requests": "ver solicitudes de volcado de importación privadas",
 	"echo-category-title-importdump-new-request": "Nueva solicitud de volcado de importación",
 	"echo-category-title-importdump-request-comment": "Comentario añadido a una solicitud de volcado de importación",
 	"echo-category-title-importdump-request-status-update": "Estado actualizado para una solicitud de volcado de importación",

--- a/i18n/es.json
+++ b/i18n/es.json
@@ -9,7 +9,7 @@
 			"OriginReboot"
 		]
 	},
-	"action-handle-import-interwiki": "manejar volcado de importación interwiki",
+	"action-handle-import-request-interwiki": "manejar volcado de importación interwiki",
 	"action-handle-import-requests": "manejar solicitudes de volcado de importación de usuarios",
 	"action-request-import": "solicitar volcados de importación",
 	"action-view-private-import-requests": "ver solicitudes de volcado de importación privadas",

--- a/i18n/fr.json
+++ b/i18n/fr.json
@@ -8,10 +8,10 @@
 			"Wladek92"
 		]
 	},
-	"action-handle-import-dump-interwiki": "gérer l’import de données entre wikis",
-	"action-handle-import-dump-requests": "gérer les demandes d’import de données des utilisateurs",
-	"action-request-import-dump": "demander des imports de données",
-	"action-view-private-import-dump-requests": "consulter les demandes privées d’import de données",
+	"action-handle-import-interwiki": "gérer l’import de données entre wikis",
+	"action-handle-import-requests": "gérer les demandes d’import de données des utilisateurs",
+	"action-request-import": "demander des imports de données",
+	"action-view-private-import-requests": "consulter les demandes privées d’import de données",
 	"echo-category-title-importdump-new-request": "Nouvelle demande d’import de données",
 	"echo-category-title-importdump-request-comment": "Commentaire ajouté à une demande d’import de données",
 	"echo-category-title-importdump-request-status-update": "État mis à jour pour une demande d’import de données",
@@ -108,7 +108,7 @@
 	"importdump-usergroups-none": "néant",
 	"importdumpprivate-log-header": "Voici un journal de toutes les demandes d’import de données et des mises à jour de leur état, dont les cibles sont des wikis privés.",
 	"importdumpprivate-log-name": "Journal privé des demandes d’import de données",
-	"ipb-action-request-import-dump": "Demander des imports de données",
+	"ipb-action-request-import": "Demander des imports de données",
 	"log-action-filter-importdump": "Type d’action :",
 	"log-action-filter-importdump-interwiki": "Modifications de la table interwiki",
 	"log-action-filter-importdump-request": "Nouvelles demandes soumises",
@@ -125,8 +125,8 @@
 	"logentry-importdumpprivate-statusupdate": "$1 a mis à jour l’état de la demande privée d’import de données $4 à « $5 ».",
 	"requestimportdump": "Demander un import de données",
 	"requestimportdumpqueue": "File d’attente des demandes d’import",
-	"right-handle-import-dump-interwiki": "Gérer l’importation de données entre wikis",
-	"right-handle-import-dump-requests": "Gérer les demandes d’import de données des utilisateurs",
-	"right-request-import-dump": "Demander des imports de données",
-	"right-view-private-import-dump-requests": "Consulter les demandes privées d’import de données"
+	"right-handle-import-interwiki": "Gérer l’importation de données entre wikis",
+	"right-handle-import-requests": "Gérer les demandes d’import de données des utilisateurs",
+	"right-request-import": "Demander des imports de données",
+	"right-view-private-import-requests": "Consulter les demandes privées d’import de données"
 }

--- a/i18n/fr.json
+++ b/i18n/fr.json
@@ -8,7 +8,7 @@
 			"Wladek92"
 		]
 	},
-	"action-handle-import-interwiki": "gérer l’import de données entre wikis",
+	"action-handle-import-request-interwiki": "gérer l’import de données entre wikis",
 	"action-handle-import-requests": "gérer les demandes d’import de données des utilisateurs",
 	"action-request-import": "demander des imports de données",
 	"action-view-private-import-requests": "consulter les demandes privées d’import de données",
@@ -125,7 +125,7 @@
 	"logentry-importdumpprivate-statusupdate": "$1 a mis à jour l’état de la demande privée d’import de données $4 à « $5 ».",
 	"requestimportdump": "Demander un import de données",
 	"requestimportdumpqueue": "File d’attente des demandes d’import",
-	"right-handle-import-interwiki": "Gérer l’importation de données entre wikis",
+	"right-handle-import-request-interwiki": "Gérer l’importation de données entre wikis",
 	"right-handle-import-requests": "Gérer les demandes d’import de données des utilisateurs",
 	"right-request-import": "Demander des imports de données",
 	"right-view-private-import-requests": "Consulter les demandes privées d’import de données"

--- a/i18n/he.json
+++ b/i18n/he.json
@@ -5,10 +5,10 @@
 			"YaronSh"
 		]
 	},
-	"action-handle-import-dump-interwiki": "לטפל בקידומות בינוויקי מרוחקות עבור בקשות יבוא",
-	"action-handle-import-dump-requests": "לטפל בבקשות יבוא של משתמשים",
-	"action-request-import-dump": "לבקש פעולות יבוא",
-	"action-view-private-import-dump-requests": "לצפות בבקשות יבוא פרטיות",
+	"action-handle-import-interwiki": "לטפל בקידומות בינוויקי מרוחקות עבור בקשות יבוא",
+	"action-handle-import-requests": "לטפל בבקשות יבוא של משתמשים",
+	"action-request-import": "לבקש פעולות יבוא",
+	"action-view-private-import-requests": "לצפות בבקשות יבוא פרטיות",
 	"echo-category-title-importdump-import-failed": "בקשת היבוא נכשלה",
 	"echo-category-title-importdump-new-request": "בקשת יבוא חדשה",
 	"echo-category-title-importdump-request-comment": "נוספה הערה לבקשת יבוא",
@@ -111,7 +111,7 @@
 	"importdump-usergroups-none": "אין",
 	"importdumpprivate-log-header": "זה יומן של כל בקשות היבוא ועדכוני המצב לבקשות עם יעדים שהם אתרי ויקי פרטיים.",
 	"importdumpprivate-log-name": "יומן בקשות יבוא פרטי",
-	"ipb-action-request-import-dump": "בקשת יבוא",
+	"ipb-action-request-import": "בקשת יבוא",
 	"log-action-filter-importdump": "סוג הפעולה:",
 	"log-action-filter-importdump-interwiki": "שינויים בטבלה interwiki",
 	"log-action-filter-importdump-request": "בקשות חדשות שנשלחו",
@@ -134,8 +134,8 @@
 	"requestimportdumpqueue": "תור בקשות יבוא",
 	"requestimportdumpqueue-header": "חיפוש בקשות יבוא",
 	"requestimportdumpqueue-header-info": "אפשר להשתמש בטופס הזה כדי לחפש בקשות יבוא. הפרמטרים למטה מכווננים את החיפוש שלך.",
-	"right-handle-import-dump-interwiki": "טיפול בקידומות בינוויקי מרוחקות עבור בקשות יבוא",
-	"right-handle-import-dump-requests": "טיפול בבקשות יבוא של משתמשים",
-	"right-request-import-dump": "לבקש יבוא",
-	"right-view-private-import-dump-requests": "צפייה הבקשות יבוא פרטיות"
+	"right-handle-import-interwiki": "טיפול בקידומות בינוויקי מרוחקות עבור בקשות יבוא",
+	"right-handle-import-requests": "טיפול בבקשות יבוא של משתמשים",
+	"right-request-import": "לבקש יבוא",
+	"right-view-private-import-requests": "צפייה הבקשות יבוא פרטיות"
 }

--- a/i18n/he.json
+++ b/i18n/he.json
@@ -5,7 +5,7 @@
 			"YaronSh"
 		]
 	},
-	"action-handle-import-interwiki": "לטפל בקידומות בינוויקי מרוחקות עבור בקשות יבוא",
+	"action-handle-import-request-interwiki": "לטפל בקידומות בינוויקי מרוחקות עבור בקשות יבוא",
 	"action-handle-import-requests": "לטפל בבקשות יבוא של משתמשים",
 	"action-request-import": "לבקש פעולות יבוא",
 	"action-view-private-import-requests": "לצפות בבקשות יבוא פרטיות",
@@ -134,7 +134,7 @@
 	"requestimportdumpqueue": "תור בקשות יבוא",
 	"requestimportdumpqueue-header": "חיפוש בקשות יבוא",
 	"requestimportdumpqueue-header-info": "אפשר להשתמש בטופס הזה כדי לחפש בקשות יבוא. הפרמטרים למטה מכווננים את החיפוש שלך.",
-	"right-handle-import-interwiki": "טיפול בקידומות בינוויקי מרוחקות עבור בקשות יבוא",
+	"right-handle-import-request-interwiki": "טיפול בקידומות בינוויקי מרוחקות עבור בקשות יבוא",
 	"right-handle-import-requests": "טיפול בבקשות יבוא של משתמשים",
 	"right-request-import": "לבקש יבוא",
 	"right-view-private-import-requests": "צפייה הבקשות יבוא פרטיות"

--- a/i18n/ia.json
+++ b/i18n/ia.json
@@ -5,7 +5,7 @@
 			"McDutchie"
 		]
 	},
-	"action-handle-import-interwiki": "gerer importationes de datos inter wikis",
+	"action-handle-import-request-interwiki": "gerer importationes de datos inter wikis",
 	"action-handle-import-requests": "gerer requestas de usatores concernente le importation",
 	"action-request-import": "requestar importationes",
 	"action-view-private-import-requests": "vider requestas private de importation",
@@ -119,7 +119,7 @@
 	"logentry-importdumpprivate-statusupdate": "$1 ha cambiate le stato del requesta private de importation de datos $4 a '$5'.",
 	"requestimportdump": "Requestar importation",
 	"requestimportdumpqueue": "Cauda de requestas de importation",
-	"right-handle-import-interwiki": "Gerer importationes de datos inter wikis",
+	"right-handle-import-request-interwiki": "Gerer importationes de datos inter wikis",
 	"right-handle-import-requests": "Gerer requestas de usatores concernente le importation de datos",
 	"right-request-import": "Requestar importationes",
 	"right-view-private-import-requests": "Vider requestas private de importation"

--- a/i18n/ia.json
+++ b/i18n/ia.json
@@ -5,10 +5,10 @@
 			"McDutchie"
 		]
 	},
-	"action-handle-import-dump-interwiki": "gerer importationes de datos inter wikis",
-	"action-handle-import-dump-requests": "gerer requestas de usatores concernente le importation",
-	"action-request-import-dump": "requestar importationes",
-	"action-view-private-import-dump-requests": "vider requestas private de importation",
+	"action-handle-import-interwiki": "gerer importationes de datos inter wikis",
+	"action-handle-import-requests": "gerer requestas de usatores concernente le importation",
+	"action-request-import": "requestar importationes",
+	"action-view-private-import-requests": "vider requestas private de importation",
 	"echo-category-title-importdump-new-request": "Nove requesta de importation de datos",
 	"echo-category-title-importdump-request-comment": "Commento addite a un requesta de importation de datos",
 	"echo-category-title-importdump-request-status-update": "Stato actualisate pro un requesta de importation de datos",
@@ -102,7 +102,7 @@
 	"importdump-usergroups-none": "necun",
 	"importdumpprivate-log-header": "Isto es un registro de tote le requestas de importation e cambiamentos de stato pro le requestas con destinationes que es wikis private.",
 	"importdumpprivate-log-name": "Registro private de requestas de importation",
-	"ipb-action-request-import-dump": "Requestar importationes",
+	"ipb-action-request-import": "Requestar importationes",
 	"log-action-filter-importdump": "Typo de action:",
 	"log-action-filter-importdump-interwiki": "Modificationes del tabella interwiki",
 	"log-action-filter-importdump-request": "Nove requestas submittite",
@@ -119,8 +119,8 @@
 	"logentry-importdumpprivate-statusupdate": "$1 ha cambiate le stato del requesta private de importation de datos $4 a '$5'.",
 	"requestimportdump": "Requestar importation",
 	"requestimportdumpqueue": "Cauda de requestas de importation",
-	"right-handle-import-dump-interwiki": "Gerer importationes de datos inter wikis",
-	"right-handle-import-dump-requests": "Gerer requestas de usatores concernente le importation de datos",
-	"right-request-import-dump": "Requestar importationes",
-	"right-view-private-import-dump-requests": "Vider requestas private de importation"
+	"right-handle-import-interwiki": "Gerer importationes de datos inter wikis",
+	"right-handle-import-requests": "Gerer requestas de usatores concernente le importation de datos",
+	"right-request-import": "Requestar importationes",
+	"right-view-private-import-requests": "Vider requestas private de importation"
 }

--- a/i18n/ja.json
+++ b/i18n/ja.json
@@ -15,7 +15,7 @@
 			"背番号4のエース"
 		]
 	},
-	"action-handle-import-interwiki": "インポートダンプのインターウィキの処理",
+	"action-handle-import-request-interwiki": "インポートダンプのインターウィキの処理",
 	"action-handle-import-requests": "利用者取り込みリクエストの処理",
 	"action-request-import": "取り込みのリクエスト",
 	"action-view-private-import-requests": "非公開の取り込みリクエストの閲覧",
@@ -133,7 +133,7 @@
 	"logentry-importdumpprivate-statusupdate": "$1 が非公開ダンプ取り込みリクエスト $4 のステータスを '$5' に{{GENDER:$2|更新}}しました。",
 	"requestimportdump": "取り込みをリクエストする",
 	"requestimportdumpqueue": "取り込みリクエストキュー",
-	"right-handle-import-interwiki": "インポート ダンプのインターウィキの処理",
+	"right-handle-import-request-interwiki": "インポート ダンプのインターウィキの処理",
 	"right-handle-import-requests": "利用者によるインポートダンプリクエストを処理",
 	"right-request-import": "取り込みをリクエスト",
 	"right-view-private-import-requests": "非公開の取り込みリクエストを閲覧"

--- a/i18n/ja.json
+++ b/i18n/ja.json
@@ -15,10 +15,10 @@
 			"背番号4のエース"
 		]
 	},
-	"action-handle-import-dump-interwiki": "インポートダンプのインターウィキの処理",
-	"action-handle-import-dump-requests": "利用者取り込みリクエストの処理",
-	"action-request-import-dump": "取り込みのリクエスト",
-	"action-view-private-import-dump-requests": "非公開の取り込みリクエストの閲覧",
+	"action-handle-import-interwiki": "インポートダンプのインターウィキの処理",
+	"action-handle-import-requests": "利用者取り込みリクエストの処理",
+	"action-request-import": "取り込みのリクエスト",
+	"action-view-private-import-requests": "非公開の取り込みリクエストの閲覧",
 	"echo-category-title-importdump-new-request": "新しくダンプインポートを要求",
 	"echo-category-title-importdump-request-comment": "インポートダンプリクエストにコメントが追加されました",
 	"echo-category-title-importdump-request-status-update": "インポートダンプのリクエストが更新されました",
@@ -114,7 +114,7 @@
 	"importdump-usergroups-none": "なし",
 	"importdumpprivate-log-header": "これは、すべてのインポート リクエストと、プライベート Wiki をターゲットとするリクエストのステータス更新のログです。",
 	"importdumpprivate-log-name": "取り込みリクエスト非公開記録",
-	"ipb-action-request-import-dump": "取り込みをリクエスト",
+	"ipb-action-request-import": "取り込みをリクエスト",
 	"log-action-filter-importdump": "操作の種類:",
 	"log-action-filter-importdump-interwiki": "Interwiki テーブルの変更",
 	"log-action-filter-importdump-request": "新しいリクエストが送信されました。",
@@ -133,8 +133,8 @@
 	"logentry-importdumpprivate-statusupdate": "$1 が非公開ダンプ取り込みリクエスト $4 のステータスを '$5' に{{GENDER:$2|更新}}しました。",
 	"requestimportdump": "取り込みをリクエストする",
 	"requestimportdumpqueue": "取り込みリクエストキュー",
-	"right-handle-import-dump-interwiki": "インポート ダンプのインターウィキの処理",
-	"right-handle-import-dump-requests": "利用者によるインポートダンプリクエストを処理",
-	"right-request-import-dump": "取り込みをリクエスト",
-	"right-view-private-import-dump-requests": "非公開の取り込みリクエストを閲覧"
+	"right-handle-import-interwiki": "インポート ダンプのインターウィキの処理",
+	"right-handle-import-requests": "利用者によるインポートダンプリクエストを処理",
+	"right-request-import": "取り込みをリクエスト",
+	"right-view-private-import-requests": "非公開の取り込みリクエストを閲覧"
 }

--- a/i18n/lt.json
+++ b/i18n/lt.json
@@ -5,8 +5,8 @@
 			"Nokeoo"
 		]
 	},
-	"action-request-import-dump": "prašyti importavimų",
-	"action-view-private-import-dump-requests": "peržiūrėti privačius importavimo prašymus",
+	"action-request-import": "prašyti importavimų",
+	"action-view-private-import-requests": "peržiūrėti privačius importavimo prašymus",
 	"echo-pref-tooltip-importdump-new-request": "Pranešti man, kai yra naujų importo užklausų.",
 	"echo-pref-tooltip-importdump-request-comment": "Pranešti man, kai yra importo užklausos, kurioje dalyvavau, komentaras.",
 	"importdump-button-copy": "(Kopijuoti į iškarpinę)",
@@ -83,7 +83,7 @@
 	"importdump-usergroups-none": "nėra",
 	"importdumpprivate-log-header": "Tai visų importavimo užklausų ir užklausų su tikslais, kurie yra privatūs viki, būsenos atnaujinimų žurnalas.",
 	"importdumpprivate-log-name": "Importavimo užklausų privatus žurnalas",
-	"ipb-action-request-import-dump": "Prašyti importavimo",
+	"ipb-action-request-import": "Prašyti importavimo",
 	"log-action-filter-importdump": "Veiklos tipas:",
 	"log-action-filter-importdump-request": "Pateikti nauji prašymai",
 	"log-action-filter-importdump-statusupdate": "Užklausų būsena atnaujinta",
@@ -92,6 +92,6 @@
 	"log-action-filter-importdumpprivate-statusupdate": "Užklausų būsena atnaujinta",
 	"requestimportdump": "Prašyti importavimo",
 	"requestimportdumpqueue": "Importavimo užklausų eilė",
-	"right-request-import-dump": "Prašyti importavimų",
-	"right-view-private-import-dump-requests": "Peržiūrėti privačius importavimo prašymus"
+	"right-request-import": "Prašyti importavimų",
+	"right-view-private-import-requests": "Peržiūrėti privačius importavimo prašymus"
 }

--- a/i18n/mk.json
+++ b/i18n/mk.json
@@ -6,10 +6,10 @@
 			"Vlad5250"
 		]
 	},
-	"action-handle-import-dump-interwiki": "работа со меѓувики за складишни извадоци на увози",
-	"action-handle-import-dump-requests": "работа со кориснички барања за увоз",
-	"action-request-import-dump": "барање за увоз",
-	"action-view-private-import-dump-requests": "гледање на приватни барања за увоз",
+	"action-handle-import-interwiki": "работа со меѓувики за складишни извадоци на увози",
+	"action-handle-import-requests": "работа со кориснички барања за увоз",
+	"action-request-import": "барање за увоз",
+	"action-view-private-import-requests": "гледање на приватни барања за увоз",
 	"echo-category-title-importdump-import-failed": "Барањето за увоз на резервниот склад не успеа",
 	"echo-category-title-importdump-new-request": "Ново барање за складиштен извадок на увози",
 	"echo-category-title-importdump-request-comment": "Додаден коментар во барање за складиштен извадок на увоз",
@@ -113,7 +113,7 @@
 	"importdump-usergroups-none": "нема",
 	"importdumpprivate-log-header": "Ова е дневник на сите барања за увоз и состојбени измени на барања со цели кои се приватни викија.",
 	"importdumpprivate-log-name": "Приватен дневник на барања за увоз",
-	"ipb-action-request-import-dump": "Барање за увози",
+	"ipb-action-request-import": "Барање за увози",
 	"log-action-filter-importdump": "Вид дејство:",
 	"log-action-filter-importdump-interwiki": "Измени во меѓувики-табела",
 	"log-action-filter-importdump-request": "Поднесено ново барање",
@@ -136,8 +136,8 @@
 	"requestimportdumpqueue": "Редица на барања за увоз",
 	"requestimportdumpqueue-header": "Пребарај барања за увоз",
 	"requestimportdumpqueue-header-info": "Со овој образец можете да увезувате барања. Послужете се со параметрите подолу за да го уточните пребарувањето.",
-	"right-handle-import-dump-interwiki": "Работа со меѓувики за складишни извадоци на увози",
-	"right-handle-import-dump-requests": "Работа со кориснички барања за складишни извадоци на увози",
-	"right-request-import-dump": "Барање на увози",
-	"right-view-private-import-dump-requests": "Преглед на приватни барања за увоз"
+	"right-handle-import-interwiki": "Работа со меѓувики за складишни извадоци на увози",
+	"right-handle-import-requests": "Работа со кориснички барања за складишни извадоци на увози",
+	"right-request-import": "Барање на увози",
+	"right-view-private-import-requests": "Преглед на приватни барања за увоз"
 }

--- a/i18n/mk.json
+++ b/i18n/mk.json
@@ -6,7 +6,7 @@
 			"Vlad5250"
 		]
 	},
-	"action-handle-import-interwiki": "работа со меѓувики за складишни извадоци на увози",
+	"action-handle-import-request-interwiki": "работа со меѓувики за складишни извадоци на увози",
 	"action-handle-import-requests": "работа со кориснички барања за увоз",
 	"action-request-import": "барање за увоз",
 	"action-view-private-import-requests": "гледање на приватни барања за увоз",
@@ -136,7 +136,7 @@
 	"requestimportdumpqueue": "Редица на барања за увоз",
 	"requestimportdumpqueue-header": "Пребарај барања за увоз",
 	"requestimportdumpqueue-header-info": "Со овој образец можете да увезувате барања. Послужете се со параметрите подолу за да го уточните пребарувањето.",
-	"right-handle-import-interwiki": "Работа со меѓувики за складишни извадоци на увози",
+	"right-handle-import-request-interwiki": "Работа со меѓувики за складишни извадоци на увози",
 	"right-handle-import-requests": "Работа со кориснички барања за складишни извадоци на увози",
 	"right-request-import": "Барање на увози",
 	"right-view-private-import-requests": "Преглед на приватни барања за увоз"

--- a/i18n/nl.json
+++ b/i18n/nl.json
@@ -6,7 +6,7 @@
 			"McDutchie"
 		]
 	},
-	"action-handle-import-interwiki": "importdumps tussen wiki's af te handelen",
+	"action-handle-import-request-interwiki": "importdumps tussen wiki's af te handelen",
 	"action-handle-import-requests": "importaanvragen van gebruikers af te handelen",
 	"action-request-import": "importen aan te vragen",
 	"action-view-private-import-requests": "privé-importaanvragen te bekijken",
@@ -120,7 +120,7 @@
 	"logentry-importdumpprivate-statusupdate": "$1 heeft de status van het privé-importdumpverzoek $4 bijgewerkt naar '$5'.",
 	"requestimportdump": "Import aanvragen",
 	"requestimportdumpqueue": "Wachtrij importaanvragen",
-	"right-handle-import-interwiki": "Importdumps tussen wiki's afhandelen",
+	"right-handle-import-request-interwiki": "Importdumps tussen wiki's afhandelen",
 	"right-handle-import-requests": "Aanvragen voor importdumps van gebruikers afhandelen",
 	"right-request-import": "Importen aanvragen",
 	"right-view-private-import-requests": "Privé-importaanvragen bekijken"

--- a/i18n/nl.json
+++ b/i18n/nl.json
@@ -6,10 +6,10 @@
 			"McDutchie"
 		]
 	},
-	"action-handle-import-dump-interwiki": "importdumps tussen wiki's af te handelen",
-	"action-handle-import-dump-requests": "importaanvragen van gebruikers af te handelen",
-	"action-request-import-dump": "importen aan te vragen",
-	"action-view-private-import-dump-requests": "privé-importaanvragen te bekijken",
+	"action-handle-import-interwiki": "importdumps tussen wiki's af te handelen",
+	"action-handle-import-requests": "importaanvragen van gebruikers af te handelen",
+	"action-request-import": "importen aan te vragen",
+	"action-view-private-import-requests": "privé-importaanvragen te bekijken",
 	"echo-category-title-importdump-new-request": "Nieuwe importdumpaanvraag",
 	"echo-category-title-importdump-request-comment": "Opmerking toegevoegd aan een importdumpaanvraag",
 	"echo-category-title-importdump-request-status-update": "Status bijgewerkt voor een importdumpaanvraag",
@@ -103,7 +103,7 @@
 	"importdump-usergroups-none": "geen",
 	"importdumpprivate-log-header": "Dit is een logboek van alle importaanvragen en statusupdates voor aanvragen met doelen die privéwiki's zijn.",
 	"importdumpprivate-log-name": "Privélogboek importaanvragen",
-	"ipb-action-request-import-dump": "Importen aanvragen",
+	"ipb-action-request-import": "Importen aanvragen",
 	"log-action-filter-importdump": "Soort handeling:",
 	"log-action-filter-importdump-interwiki": "Interwiki-tabelaanpassingen",
 	"log-action-filter-importdump-request": "Nieuwe verzoeken ingediend",
@@ -120,8 +120,8 @@
 	"logentry-importdumpprivate-statusupdate": "$1 heeft de status van het privé-importdumpverzoek $4 bijgewerkt naar '$5'.",
 	"requestimportdump": "Import aanvragen",
 	"requestimportdumpqueue": "Wachtrij importaanvragen",
-	"right-handle-import-dump-interwiki": "Importdumps tussen wiki's afhandelen",
-	"right-handle-import-dump-requests": "Aanvragen voor importdumps van gebruikers afhandelen",
-	"right-request-import-dump": "Importen aanvragen",
-	"right-view-private-import-dump-requests": "Privé-importaanvragen bekijken"
+	"right-handle-import-interwiki": "Importdumps tussen wiki's afhandelen",
+	"right-handle-import-requests": "Aanvragen voor importdumps van gebruikers afhandelen",
+	"right-request-import": "Importen aanvragen",
+	"right-view-private-import-requests": "Privé-importaanvragen bekijken"
 }

--- a/i18n/pt.json
+++ b/i18n/pt.json
@@ -5,7 +5,7 @@
 			"Hamilton Abreu"
 		]
 	},
-	"action-handle-import-interwiki": "tratar de importações de cópias em ficheiro entre wikis",
+	"action-handle-import-request-interwiki": "tratar de importações de cópias em ficheiro entre wikis",
 	"action-handle-import-requests": "tratar de pedidos dos utilizadores para importação de cópias em ficheiro",
 	"action-request-import": "pedir a importação de cópias em ficheiro",
 	"action-view-private-import-requests": "ver pedidos privados de importação de cópias em ficheiro",
@@ -120,7 +120,7 @@
 	"logentry-importdumpprivate-statusupdate": "$1 atualizou o estado do pedido privado de importação de cópia em ficheiro $4 para '$5'.",
 	"requestimportdump": "Pedir importação de cópia em ficheiro",
 	"requestimportdumpqueue": "Fila de espera de pedidos de importação de cópia em ficheiro",
-	"right-handle-import-interwiki": "Tratar de importações de cópias em ficheiro entre wikis",
+	"right-handle-import-request-interwiki": "Tratar de importações de cópias em ficheiro entre wikis",
 	"right-handle-import-requests": "Tratar de pedidos dos utilizadores para importação de cópias em ficheiro",
 	"right-request-import": "Pedir importação de cópias em ficheiro",
 	"right-view-private-import-requests": "Ver pedidos privados de importação de cópias em ficheiro"

--- a/i18n/pt.json
+++ b/i18n/pt.json
@@ -5,10 +5,10 @@
 			"Hamilton Abreu"
 		]
 	},
-	"action-handle-import-dump-interwiki": "tratar de importações de cópias em ficheiro entre wikis",
-	"action-handle-import-dump-requests": "tratar de pedidos dos utilizadores para importação de cópias em ficheiro",
-	"action-request-import-dump": "pedir a importação de cópias em ficheiro",
-	"action-view-private-import-dump-requests": "ver pedidos privados de importação de cópias em ficheiro",
+	"action-handle-import-interwiki": "tratar de importações de cópias em ficheiro entre wikis",
+	"action-handle-import-requests": "tratar de pedidos dos utilizadores para importação de cópias em ficheiro",
+	"action-request-import": "pedir a importação de cópias em ficheiro",
+	"action-view-private-import-requests": "ver pedidos privados de importação de cópias em ficheiro",
 	"echo-category-title-importdump-new-request": "Pedido novo de importação de uma cópia em ficheiro",
 	"echo-category-title-importdump-request-comment": "Foi adicionado um comentário a um pedido de importação de uma cópia em ficheiro",
 	"echo-category-title-importdump-request-status-update": "Foi atualizado o estado de um pedido de importação de cópia em ficheiro",
@@ -103,7 +103,7 @@
 	"importdump-usergroups-none": "nenhum",
 	"importdumpprivate-log-header": "Este registo é de todos os pedidos de importação de cópias em ficheiro e de atualizações dos respetivos estados, para pedidos com destinos que são wikis privadas.",
 	"importdumpprivate-log-name": "Registo de pedidos privados de importação de cópias em ficheiro",
-	"ipb-action-request-import-dump": "Pedir importação de cópias em ficheiro",
+	"ipb-action-request-import": "Pedir importação de cópias em ficheiro",
 	"log-action-filter-importdump": "Tipo de operação:",
 	"log-action-filter-importdump-interwiki": "Modificações da tabela de interwikis",
 	"log-action-filter-importdump-request": "Novos pedidos submetidos",
@@ -120,8 +120,8 @@
 	"logentry-importdumpprivate-statusupdate": "$1 atualizou o estado do pedido privado de importação de cópia em ficheiro $4 para '$5'.",
 	"requestimportdump": "Pedir importação de cópia em ficheiro",
 	"requestimportdumpqueue": "Fila de espera de pedidos de importação de cópia em ficheiro",
-	"right-handle-import-dump-interwiki": "Tratar de importações de cópias em ficheiro entre wikis",
-	"right-handle-import-dump-requests": "Tratar de pedidos dos utilizadores para importação de cópias em ficheiro",
-	"right-request-import-dump": "Pedir importação de cópias em ficheiro",
-	"right-view-private-import-dump-requests": "Ver pedidos privados de importação de cópias em ficheiro"
+	"right-handle-import-interwiki": "Tratar de importações de cópias em ficheiro entre wikis",
+	"right-handle-import-requests": "Tratar de pedidos dos utilizadores para importação de cópias em ficheiro",
+	"right-request-import": "Pedir importação de cópias em ficheiro",
+	"right-view-private-import-requests": "Ver pedidos privados de importação de cópias em ficheiro"
 }

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -8,10 +8,10 @@
 			"Verdy p"
 		]
 	},
-	"action-handle-import-dump-interwiki": "{{doc-action|handle-import-dump-interwiki}}",
-	"action-handle-import-dump-requests": "{{doc-action|handle-import-dump-requests}}",
-	"action-request-import-dump": "{{doc-action|request-import-dump}}",
-	"action-view-private-import-dump-requests": "{{doc-action|view-private-import-dump-requests}}",
+	"action-handle-import-interwiki": "{{doc-action|handle-import-interwiki}}",
+	"action-handle-import-requests": "{{doc-action|handle-import-requests}}",
+	"action-request-import": "{{doc-action|request-import}}",
+	"action-view-private-import-requests": "{{doc-action|view-private-import-requests}}",
 	"echo-category-title-importdump-import-failed": "Echo category title for {{msg-mw|echo-category-title-importdump-import-failed}}.",
 	"echo-category-title-importdump-new-request": "Echo category title for {{msg-mw|echo-category-title-importdump-new-request}}.",
 	"echo-category-title-importdump-request-comment": "Echo category title for {{msg-mw|echo-category-title-importdump-request-comment}}.",
@@ -115,7 +115,7 @@
 	"importdump-usergroups-none": "Displayed value if the requester has no user groups on the target wiki.",
 	"importdumpprivate-log-header": "Header for the ImportDump private log.",
 	"importdumpprivate-log-name": "{{doc-logpage}}",
-	"ipb-action-request-import-dump": "The label for the action select option on [[Special:Block]] to block a user from requesting import dumps.",
+	"ipb-action-request-import": "The label for the action select option on [[Special:Block]] to block a user from requesting import dumps.",
 	"log-action-filter-importdump": "{{doc-log-action-filter-type|importdump}}\n{{identical|Type of action}}\n{{related|Log-action-filter}}",
 	"log-action-filter-importdump-interwiki": "{{doc-log-action-filter-action|importdump|interwiki}}",
 	"log-action-filter-importdump-request": "{{doc-log-action-filter-action|importdump|request}}",
@@ -138,8 +138,8 @@
 	"requestimportdumpqueue": "{{doc-special}}",
 	"requestimportdumpqueue-header": "Legend header for special page",
 	"requestimportdumpqueue-header-info": "Information under legend header.",
-	"right-handle-import-dump-interwiki": "{{doc-right|handle-import-dump-interwiki}}",
-	"right-handle-import-dump-requests": "{{doc-right|handle-import-dump-requests}}",
-	"right-request-import-dump": "{{doc-right|request-import-dump}}",
-	"right-view-private-import-dump-requests": "{{doc-right|view-private-import-dump-requests}}"
+	"right-handle-import-interwiki": "{{doc-right|handle-import-interwiki}}",
+	"right-handle-import-requests": "{{doc-right|handle-import-requests}}",
+	"right-request-import": "{{doc-right|request-import}}",
+	"right-view-private-import-requests": "{{doc-right|view-private-import-requests}}"
 }

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -8,7 +8,7 @@
 			"Verdy p"
 		]
 	},
-	"action-handle-import-interwiki": "{{doc-action|handle-import-interwiki}}",
+	"action-handle-import-request-interwiki": "{{doc-action|handle-import-request-interwiki}}",
 	"action-handle-import-requests": "{{doc-action|handle-import-requests}}",
 	"action-request-import": "{{doc-action|request-import}}",
 	"action-view-private-import-requests": "{{doc-action|view-private-import-requests}}",
@@ -138,7 +138,7 @@
 	"requestimportdumpqueue": "{{doc-special}}",
 	"requestimportdumpqueue-header": "Legend header for special page",
 	"requestimportdumpqueue-header-info": "Information under legend header.",
-	"right-handle-import-interwiki": "{{doc-right|handle-import-interwiki}}",
+	"right-handle-import-request-interwiki": "{{doc-right|handle-import-request-interwiki}}",
 	"right-handle-import-requests": "{{doc-right|handle-import-requests}}",
 	"right-request-import": "{{doc-right|request-import}}",
 	"right-view-private-import-requests": "{{doc-right|view-private-import-requests}}"

--- a/i18n/ru.json
+++ b/i18n/ru.json
@@ -8,7 +8,7 @@
 			"Артём 13327"
 		]
 	},
-	"action-handle-import-interwiki": "обработать импорт дампа interwiki",
+	"action-handle-import-request-interwiki": "обработать импорт дампа interwiki",
 	"action-handle-import-requests": "обработать запрос на импорт пользователей",
 	"action-request-import": "запросы импорта",
 	"action-view-private-import-requests": "просмотр закрытых запросов на импорт",
@@ -122,7 +122,7 @@
 	"logentry-importdumpprivate-statusupdate": "$1 {{GENDER:$1|обновил|обновила}} состояние закрытого запроса импорта дампа $4 на '$5'.",
 	"requestimportdump": "Запрос на импорт",
 	"requestimportdumpqueue": "Очередь запросов на импорт",
-	"right-handle-import-interwiki": "Обработать импорт дампа interwiki",
+	"right-handle-import-request-interwiki": "Обработать импорт дампа interwiki",
 	"right-handle-import-requests": "Обработать запрос на импорт пользователей",
 	"right-request-import": "Запросы импорта",
 	"right-view-private-import-requests": "Просмотр закрытых запросов на импорт"

--- a/i18n/ru.json
+++ b/i18n/ru.json
@@ -8,10 +8,10 @@
 			"Артём 13327"
 		]
 	},
-	"action-handle-import-dump-interwiki": "обработать импорт дампа interwiki",
-	"action-handle-import-dump-requests": "обработать запрос на импорт пользователей",
-	"action-request-import-dump": "запросы импорта",
-	"action-view-private-import-dump-requests": "просмотр закрытых запросов на импорт",
+	"action-handle-import-interwiki": "обработать импорт дампа interwiki",
+	"action-handle-import-requests": "обработать запрос на импорт пользователей",
+	"action-request-import": "запросы импорта",
+	"action-view-private-import-requests": "просмотр закрытых запросов на импорт",
 	"echo-category-title-importdump-new-request": "Новый запрос на импорт дампа",
 	"echo-category-title-importdump-request-comment": "Комментарий, добавленный к запросу на импорт дампа",
 	"echo-category-title-importdump-request-status-update": "Обновлено состояние запроса на импорт дампа",
@@ -105,7 +105,7 @@
 	"importdump-usergroups-none": "нет",
 	"importdumpprivate-log-header": "Это журнал всех запросов на импорт и обновления состояния для запросов, целью которых являются закрытые вики.",
 	"importdumpprivate-log-name": "Закрытый журнал импорта запросов",
-	"ipb-action-request-import-dump": "Запрос на импорт",
+	"ipb-action-request-import": "Запрос на импорт",
 	"log-action-filter-importdump": "Тип действия:",
 	"log-action-filter-importdump-interwiki": "Модификации таблиц интервики",
 	"log-action-filter-importdump-request": "Новые запросы поданы",
@@ -122,8 +122,8 @@
 	"logentry-importdumpprivate-statusupdate": "$1 {{GENDER:$1|обновил|обновила}} состояние закрытого запроса импорта дампа $4 на '$5'.",
 	"requestimportdump": "Запрос на импорт",
 	"requestimportdumpqueue": "Очередь запросов на импорт",
-	"right-handle-import-dump-interwiki": "Обработать импорт дампа interwiki",
-	"right-handle-import-dump-requests": "Обработать запрос на импорт пользователей",
-	"right-request-import-dump": "Запросы импорта",
-	"right-view-private-import-dump-requests": "Просмотр закрытых запросов на импорт"
+	"right-handle-import-interwiki": "Обработать импорт дампа interwiki",
+	"right-handle-import-requests": "Обработать запрос на импорт пользователей",
+	"right-request-import": "Запросы импорта",
+	"right-view-private-import-requests": "Просмотр закрытых запросов на импорт"
 }

--- a/i18n/sh-cyrl.json
+++ b/i18n/sh-cyrl.json
@@ -5,10 +5,10 @@
 			"Vlad5250"
 		]
 	},
-	"action-handle-import-dump-interwiki": "руковате међувикије за складишне извадке увоза",
-	"action-handle-import-dump-requests": "руковате корисничке захтјеве за увоз",
-	"action-request-import-dump": "захтјевате увоз",
-	"action-view-private-import-dump-requests": "гледате приватне захтјеве за увоз",
+	"action-handle-import-interwiki": "руковате међувикије за складишне извадке увоза",
+	"action-handle-import-requests": "руковате корисничке захтјеве за увоз",
+	"action-request-import": "захтјевате увоз",
+	"action-view-private-import-requests": "гледате приватне захтјеве за увоз",
 	"echo-category-title-importdump-new-request": "Нови захтјев за складишни извадак увоза",
 	"echo-category-title-importdump-request-comment": "Додан је коментар у захтјев за складишни извадак увоза",
 	"echo-category-title-importdump-request-status-update": "Промијењен статус захтјева за складишни извадак увоза",
@@ -102,7 +102,7 @@
 	"importdump-usergroups-none": "ништа",
 	"importdumpprivate-log-header": "Ово је дневник свих захтјева за увоз и промјена статуса захтјева с циљевима који су приватни викији.",
 	"importdumpprivate-log-name": "Приватни дневник захтјева за увоз",
-	"ipb-action-request-import-dump": "Захтјеви за увоз",
+	"ipb-action-request-import": "Захтјеви за увоз",
 	"log-action-filter-importdump": "Врста радње:",
 	"log-action-filter-importdump-interwiki": "Промјене табле међувикија",
 	"log-action-filter-importdump-request": "Поднесен нови захтјев",
@@ -119,8 +119,8 @@
 	"logentry-importdumpprivate-statusupdate": "$1 је промијенио(ла) статус захтјева приватног складишног извадка увоза $4 за у „$5“.",
 	"requestimportdump": "Захтјев за увоз",
 	"requestimportdumpqueue": "Ред захтјева за увоз",
-	"right-handle-import-dump-interwiki": "Руковање међувикија за складишне извадке увоза",
-	"right-handle-import-dump-requests": "Руковање корисничких захтјева за увоз",
-	"right-request-import-dump": "Захтјев за увоз",
-	"right-view-private-import-dump-requests": "Прегледање приватних захтјева за увоз"
+	"right-handle-import-interwiki": "Руковање међувикија за складишне извадке увоза",
+	"right-handle-import-requests": "Руковање корисничких захтјева за увоз",
+	"right-request-import": "Захтјев за увоз",
+	"right-view-private-import-requests": "Прегледање приватних захтјева за увоз"
 }

--- a/i18n/sh-cyrl.json
+++ b/i18n/sh-cyrl.json
@@ -5,7 +5,7 @@
 			"Vlad5250"
 		]
 	},
-	"action-handle-import-interwiki": "руковате међувикије за складишне извадке увоза",
+	"action-handle-import-request-interwiki": "руковате међувикије за складишне извадке увоза",
 	"action-handle-import-requests": "руковате корисничке захтјеве за увоз",
 	"action-request-import": "захтјевате увоз",
 	"action-view-private-import-requests": "гледате приватне захтјеве за увоз",
@@ -119,7 +119,7 @@
 	"logentry-importdumpprivate-statusupdate": "$1 је промијенио(ла) статус захтјева приватног складишног извадка увоза $4 за у „$5“.",
 	"requestimportdump": "Захтјев за увоз",
 	"requestimportdumpqueue": "Ред захтјева за увоз",
-	"right-handle-import-interwiki": "Руковање међувикија за складишне извадке увоза",
+	"right-handle-import-request-interwiki": "Руковање међувикија за складишне извадке увоза",
 	"right-handle-import-requests": "Руковање корисничких захтјева за увоз",
 	"right-request-import": "Захтјев за увоз",
 	"right-view-private-import-requests": "Прегледање приватних захтјева за увоз"

--- a/i18n/sh-latn.json
+++ b/i18n/sh-latn.json
@@ -6,7 +6,7 @@
 			"Winston Sung"
 		]
 	},
-	"action-handle-import-interwiki": "rukovate međuvikije za skladišne izvadke uvoza",
+	"action-handle-import-request-interwiki": "rukovate međuvikije za skladišne izvadke uvoza",
 	"action-handle-import-requests": "rukovate korisničke zahtjeve za uvoz",
 	"action-request-import": "zahtjevate uvoz",
 	"action-view-private-import-requests": "gledate privatne zahtjeve za uvoz",
@@ -121,7 +121,7 @@
 	"logentry-importdumpprivate-statusupdate": "$1 promijenio(-la) je status privatnog zahtjeva skladišnog izvadka uvoza $4 na '$5'.",
 	"requestimportdump": "Zahtjev za uvoz",
 	"requestimportdumpqueue": "Red zahtjeva za uvoz",
-	"right-handle-import-interwiki": "Rukovanje međuvikija za skladišne izvadke uvoza",
+	"right-handle-import-request-interwiki": "Rukovanje međuvikija za skladišne izvadke uvoza",
 	"right-handle-import-requests": "Rukovanje korisničkih zahtjeva za uvoze",
 	"right-request-import": "Zahtjev za uvoz",
 	"right-view-private-import-requests": "Pregledanje privatnih zahtjeva za uvoz"

--- a/i18n/sh-latn.json
+++ b/i18n/sh-latn.json
@@ -6,10 +6,10 @@
 			"Winston Sung"
 		]
 	},
-	"action-handle-import-dump-interwiki": "rukovate međuvikije za skladišne izvadke uvoza",
-	"action-handle-import-dump-requests": "rukovate korisničke zahtjeve za uvoz",
-	"action-request-import-dump": "zahtjevate uvoz",
-	"action-view-private-import-dump-requests": "gledate privatne zahtjeve za uvoz",
+	"action-handle-import-interwiki": "rukovate međuvikije za skladišne izvadke uvoza",
+	"action-handle-import-requests": "rukovate korisničke zahtjeve za uvoz",
+	"action-request-import": "zahtjevate uvoz",
+	"action-view-private-import-requests": "gledate privatne zahtjeve za uvoz",
 	"echo-category-title-importdump-new-request": "Novi zahtjev za skladišni izvadak uvoza",
 	"echo-category-title-importdump-request-comment": "Dodan je komentar u zahtjev za skladišni izvadak uvoza",
 	"echo-category-title-importdump-request-status-update": "Promijenjen status zahtjeva za skladišni izvadak uvoza",
@@ -104,7 +104,7 @@
 	"importdump-usergroups-none": "ništa",
 	"importdumpprivate-log-header": "Ovo je dnevnik svih zahtjeva za uvoz i promjena statusa zahtjeva s ciljevima koji su privatni vikiji.",
 	"importdumpprivate-log-name": "Privatni dnevnik zahtjeva za uvoz",
-	"ipb-action-request-import-dump": "Zahtjevi za uvoz",
+	"ipb-action-request-import": "Zahtjevi za uvoz",
 	"log-action-filter-importdump": "Vrsta radnje:",
 	"log-action-filter-importdump-interwiki": "Promjene table međuvikija",
 	"log-action-filter-importdump-request": "Podnesen novi zahtjev",
@@ -121,8 +121,8 @@
 	"logentry-importdumpprivate-statusupdate": "$1 promijenio(-la) je status privatnog zahtjeva skladišnog izvadka uvoza $4 na '$5'.",
 	"requestimportdump": "Zahtjev za uvoz",
 	"requestimportdumpqueue": "Red zahtjeva za uvoz",
-	"right-handle-import-dump-interwiki": "Rukovanje međuvikija za skladišne izvadke uvoza",
-	"right-handle-import-dump-requests": "Rukovanje korisničkih zahtjeva za uvoze",
-	"right-request-import-dump": "Zahtjev za uvoz",
-	"right-view-private-import-dump-requests": "Pregledanje privatnih zahtjeva za uvoz"
+	"right-handle-import-interwiki": "Rukovanje međuvikija za skladišne izvadke uvoza",
+	"right-handle-import-requests": "Rukovanje korisničkih zahtjeva za uvoze",
+	"right-request-import": "Zahtjev za uvoz",
+	"right-view-private-import-requests": "Pregledanje privatnih zahtjeva za uvoz"
 }

--- a/i18n/sl.json
+++ b/i18n/sl.json
@@ -6,7 +6,7 @@
 			"Upwinxp"
 		]
 	},
-	"action-handle-import-interwiki": "upravljanje uvoza izpisov med vikiji",
+	"action-handle-import-request-interwiki": "upravljanje uvoza izpisov med vikiji",
 	"action-handle-import-requests": "obravnavo prošenj uporabnikov za uvoz",
 	"action-request-import": "zaprositev za uvoz",
 	"action-view-private-import-requests": "ogledovanje zasebnih prošenj za uvoz",
@@ -125,7 +125,7 @@
 	"logentry-importdumpprivate-statusupdate": "$1 je posodobil_a stanje zasebne prošnje $4 za uvoz izpisa $4 v »$5«.",
 	"requestimportdump": "Prošnja za uvoz",
 	"requestimportdumpqueue": "Čakalna vrsta prošenj za uvoz",
-	"right-handle-import-interwiki": "Obravnava uvoza izpisa med vikiji",
+	"right-handle-import-request-interwiki": "Obravnava uvoza izpisa med vikiji",
 	"right-handle-import-requests": "Obravnava uporabniških prošenj za uvoz izpisa",
 	"right-request-import": "Zaprositev za uvoz",
 	"right-view-private-import-requests": "Ogledovanje zasebnih prošenj za uvoz"

--- a/i18n/sl.json
+++ b/i18n/sl.json
@@ -6,10 +6,10 @@
 			"Upwinxp"
 		]
 	},
-	"action-handle-import-dump-interwiki": "upravljanje uvoza izpisov med vikiji",
-	"action-handle-import-dump-requests": "obravnavo prošenj uporabnikov za uvoz",
-	"action-request-import-dump": "zaprositev za uvoz",
-	"action-view-private-import-dump-requests": "ogledovanje zasebnih prošenj za uvoz",
+	"action-handle-import-interwiki": "upravljanje uvoza izpisov med vikiji",
+	"action-handle-import-requests": "obravnavo prošenj uporabnikov za uvoz",
+	"action-request-import": "zaprositev za uvoz",
+	"action-view-private-import-requests": "ogledovanje zasebnih prošenj za uvoz",
 	"echo-category-title-importdump-new-request": "Nov zahtevek za uvoz izpisa",
 	"echo-category-title-importdump-request-comment": "K prošnji za uvoz izpisa je bil dodan komentar",
 	"echo-category-title-importdump-request-status-update": "Posodobitev stanja zahtevka za uvoz izpisa",
@@ -108,7 +108,7 @@
 	"importdump-usergroups-none": "nobena",
 	"importdumpprivate-log-header": "To je dnevnik vseh prošenj za uvoz in posodobitev stanja za prošnje s cilji, ki so zasebni vikiji.",
 	"importdumpprivate-log-name": "Dnevnik prošenj za uvoz",
-	"ipb-action-request-import-dump": "Zaprositev za uvoz",
+	"ipb-action-request-import": "Zaprositev za uvoz",
 	"log-action-filter-importdump": "Vrsta dejanja:",
 	"log-action-filter-importdump-interwiki": "Spremembe tabele intervikijev",
 	"log-action-filter-importdump-request": "Predložitev novih prošenj",
@@ -125,8 +125,8 @@
 	"logentry-importdumpprivate-statusupdate": "$1 je posodobil_a stanje zasebne prošnje $4 za uvoz izpisa $4 v »$5«.",
 	"requestimportdump": "Prošnja za uvoz",
 	"requestimportdumpqueue": "Čakalna vrsta prošenj za uvoz",
-	"right-handle-import-dump-interwiki": "Obravnava uvoza izpisa med vikiji",
-	"right-handle-import-dump-requests": "Obravnava uporabniških prošenj za uvoz izpisa",
-	"right-request-import-dump": "Zaprositev za uvoz",
-	"right-view-private-import-dump-requests": "Ogledovanje zasebnih prošenj za uvoz"
+	"right-handle-import-interwiki": "Obravnava uvoza izpisa med vikiji",
+	"right-handle-import-requests": "Obravnava uporabniških prošenj za uvoz izpisa",
+	"right-request-import": "Zaprositev za uvoz",
+	"right-view-private-import-requests": "Ogledovanje zasebnih prošenj za uvoz"
 }

--- a/i18n/sv.json
+++ b/i18n/sv.json
@@ -4,9 +4,9 @@
 			"Sabelöga"
 		]
 	},
-	"action-handle-import-dump-requests": "hantera importeringsbegäran från användare",
-	"action-request-import-dump": "begära att importera dumpar",
-	"action-view-private-import-dump-requests": "visa begäran att importera dumpar",
+	"action-handle-import-requests": "hantera importeringsbegäran från användare",
+	"action-request-import": "begära att importera dumpar",
+	"action-view-private-import-requests": "visa begäran att importera dumpar",
 	"importdump-label-add-comment": "Lägg till kommentar",
 	"importdump-label-all": "Alla",
 	"importdump-label-comment": "Kommentera:",

--- a/i18n/uk.json
+++ b/i18n/uk.json
@@ -8,10 +8,10 @@
 			"Пан Хаунд"
 		]
 	},
-	"action-handle-import-dump-interwiki": "обробляти інтервікі дампу імпорту",
-	"action-handle-import-dump-requests": "обробляти запити користувача на імпорт",
-	"action-request-import-dump": "запит імпортів",
-	"action-view-private-import-dump-requests": "перегляд приватних запитів на імпорт",
+	"action-handle-import-interwiki": "обробляти інтервікі дампу імпорту",
+	"action-handle-import-requests": "обробляти запити користувача на імпорт",
+	"action-request-import": "запит імпортів",
+	"action-view-private-import-requests": "перегляд приватних запитів на імпорт",
 	"echo-category-title-importdump-new-request": "Новий запит на імпорт дампа",
 	"echo-category-title-importdump-request-comment": "Додано коментар до запиту імпорту дампа",
 	"echo-category-title-importdump-request-status-update": "Оновлено статус для запиту на імпорт дампа",

--- a/i18n/uk.json
+++ b/i18n/uk.json
@@ -8,7 +8,7 @@
 			"Пан Хаунд"
 		]
 	},
-	"action-handle-import-interwiki": "обробляти інтервікі дампу імпорту",
+	"action-handle-import-request-interwiki": "обробляти інтервікі дампу імпорту",
 	"action-handle-import-requests": "обробляти запити користувача на імпорт",
 	"action-request-import": "запит імпортів",
 	"action-view-private-import-requests": "перегляд приватних запитів на імпорт",

--- a/i18n/vi.json
+++ b/i18n/vi.json
@@ -4,10 +4,10 @@
 			"Pisceskaze"
 		]
 	},
-	"action-handle-import-dump-interwiki": "xử lý liên kết liên wiki trong quá trình nhập",
-	"action-handle-import-dump-requests": "xử lý yêu cầu nhập của người dùng",
-	"action-request-import-dump": "yêu cầu nhập",
-	"action-view-private-import-dump-requests": "xem yêu cầu nhập riêng tư",
+	"action-handle-import-interwiki": "xử lý liên kết liên wiki trong quá trình nhập",
+	"action-handle-import-requests": "xử lý yêu cầu nhập của người dùng",
+	"action-request-import": "yêu cầu nhập",
+	"action-view-private-import-requests": "xem yêu cầu nhập riêng tư",
 	"echo-category-title-importdump-import-failed": "Yêu cầu nhập kết xuất không thành công",
 	"echo-category-title-importdump-new-request": "Yêu cầu nhập mới",
 	"echo-category-title-importdump-request-comment": "Đã thêm nhận xét vào yêu cầu nhập",
@@ -110,7 +110,7 @@
 	"importdump-usergroups-none": "không có",
 	"importdumpprivate-log-header": "Đây là nhật ký của tất cả các yêu cầu nhập và cập nhật trạng thái cho các yêu cầu có mục tiêu là wiki riêng tư.",
 	"importdumpprivate-log-name": "Nhật ký yêu cầu nhập riêng tư",
-	"ipb-action-request-import-dump": "Yêu cầu nhập",
+	"ipb-action-request-import": "Yêu cầu nhập",
 	"log-action-filter-importdump": "Kiểu tác vụ:",
 	"log-action-filter-importdump-interwiki": "Sửa đổi bảng liên wiki",
 	"log-action-filter-importdump-request": "Yêu cầu mới được gửi",
@@ -133,8 +133,8 @@
 	"requestimportdumpqueue": "Hàng đợi yêu cầu nhập",
 	"requestimportdumpqueue-header": "Tìm yêu cầu nhập",
 	"requestimportdumpqueue-header-info": "Bạn có thể sử dụng biểu mẫu này để tìm kiếm các yêu cầu nhập kết xuất. Sử dụng các tham số dưới đây để tinh chỉnh tìm kiếm của bạn.",
-	"right-handle-import-dump-interwiki": "Xử lý liên kết liên wiki trong quá trình nhập kết xuất",
-	"right-handle-import-dump-requests": "Xử lý yêu cầu nhập kết xuất của người dùng",
-	"right-request-import-dump": "Yêu cầu nhập kết xuất",
-	"right-view-private-import-dump-requests": "Xem yêu cầu nhập riêng tư"
+	"right-handle-import-interwiki": "Xử lý liên kết liên wiki trong quá trình nhập kết xuất",
+	"right-handle-import-requests": "Xử lý yêu cầu nhập kết xuất của người dùng",
+	"right-request-import": "Yêu cầu nhập kết xuất",
+	"right-view-private-import-requests": "Xem yêu cầu nhập riêng tư"
 }

--- a/i18n/vi.json
+++ b/i18n/vi.json
@@ -4,7 +4,7 @@
 			"Pisceskaze"
 		]
 	},
-	"action-handle-import-interwiki": "xử lý liên kết liên wiki trong quá trình nhập",
+	"action-handle-import-request-interwiki": "xử lý liên kết liên wiki trong quá trình nhập",
 	"action-handle-import-requests": "xử lý yêu cầu nhập của người dùng",
 	"action-request-import": "yêu cầu nhập",
 	"action-view-private-import-requests": "xem yêu cầu nhập riêng tư",
@@ -133,7 +133,7 @@
 	"requestimportdumpqueue": "Hàng đợi yêu cầu nhập",
 	"requestimportdumpqueue-header": "Tìm yêu cầu nhập",
 	"requestimportdumpqueue-header-info": "Bạn có thể sử dụng biểu mẫu này để tìm kiếm các yêu cầu nhập kết xuất. Sử dụng các tham số dưới đây để tinh chỉnh tìm kiếm của bạn.",
-	"right-handle-import-interwiki": "Xử lý liên kết liên wiki trong quá trình nhập kết xuất",
+	"right-handle-import-request-interwiki": "Xử lý liên kết liên wiki trong quá trình nhập kết xuất",
 	"right-handle-import-requests": "Xử lý yêu cầu nhập kết xuất của người dùng",
 	"right-request-import": "Yêu cầu nhập kết xuất",
 	"right-view-private-import-requests": "Xem yêu cầu nhập riêng tư"

--- a/i18n/zh-hans.json
+++ b/i18n/zh-hans.json
@@ -12,10 +12,10 @@
 			"阿南之人"
 		]
 	},
-	"action-handle-import-dump-interwiki": "处理跨wiki导入转储",
-	"action-handle-import-dump-requests": "处理用户导入申请",
-	"action-request-import-dump": "申请导入",
-	"action-view-private-import-dump-requests": "查看非公开导入申请",
+	"action-handle-import-interwiki": "处理跨wiki导入转储",
+	"action-handle-import-requests": "处理用户导入申请",
+	"action-request-import": "申请导入",
+	"action-view-private-import-requests": "查看非公开导入申请",
 	"echo-category-title-importdump-new-request": "新的导入转储申请",
 	"echo-category-title-importdump-request-comment": "添加到导入转储申请的意见",
 	"echo-category-title-importdump-request-status-update": "导入转储申请的状态更新",
@@ -110,7 +110,7 @@
 	"importdump-usergroups-none": "无",
 	"importdumpprivate-log-header": "这是目标为非公开wiki的所有导入申请及状态更新的日志。",
 	"importdumpprivate-log-name": "导入申请非公开日志",
-	"ipb-action-request-import-dump": "申请导入",
+	"ipb-action-request-import": "申请导入",
 	"log-action-filter-importdump": "操作类型：",
 	"log-action-filter-importdump-interwiki": "跨wiki表修改",
 	"log-action-filter-importdump-request": "提交新的申请",
@@ -127,8 +127,8 @@
 	"logentry-importdumpprivate-statusupdate": "$1将非公开导入转储申请$4的状态更新为“$5”。",
 	"requestimportdump": "申请导入",
 	"requestimportdumpqueue": "导入申请队列",
-	"right-handle-import-dump-interwiki": "处理跨wiki导入转储",
-	"right-handle-import-dump-requests": "处理用户导入转储申请",
-	"right-request-import-dump": "申请导入",
-	"right-view-private-import-dump-requests": "查看非公开导入申请"
+	"right-handle-import-interwiki": "处理跨wiki导入转储",
+	"right-handle-import-requests": "处理用户导入转储申请",
+	"right-request-import": "申请导入",
+	"right-view-private-import-requests": "查看非公开导入申请"
 }

--- a/i18n/zh-hans.json
+++ b/i18n/zh-hans.json
@@ -12,7 +12,7 @@
 			"阿南之人"
 		]
 	},
-	"action-handle-import-interwiki": "处理跨wiki导入转储",
+	"action-handle-import-request-interwiki": "处理跨wiki导入转储",
 	"action-handle-import-requests": "处理用户导入申请",
 	"action-request-import": "申请导入",
 	"action-view-private-import-requests": "查看非公开导入申请",
@@ -127,7 +127,7 @@
 	"logentry-importdumpprivate-statusupdate": "$1将非公开导入转储申请$4的状态更新为“$5”。",
 	"requestimportdump": "申请导入",
 	"requestimportdumpqueue": "导入申请队列",
-	"right-handle-import-interwiki": "处理跨wiki导入转储",
+	"right-handle-import-request-interwiki": "处理跨wiki导入转储",
 	"right-handle-import-requests": "处理用户导入转储申请",
 	"right-request-import": "申请导入",
 	"right-view-private-import-requests": "查看非公开导入申请"

--- a/i18n/zh-hant.json
+++ b/i18n/zh-hant.json
@@ -9,7 +9,7 @@
 			"铁桶"
 		]
 	},
-	"action-handle-import-interwiki": "處理跨 wiki 匯入傾印",
+	"action-handle-import-request-interwiki": "處理跨 wiki 匯入傾印",
 	"action-handle-import-requests": "處理使用者匯入申請",
 	"action-request-import": "申請匯入",
 	"action-view-private-import-requests": "檢視非公開匯入申請",
@@ -139,7 +139,7 @@
 	"requestimportdumpqueue": "匯入申請佇列",
 	"requestimportdumpqueue-header": "搜尋匯入請求",
 	"requestimportdumpqueue-header-info": "您可以使用此表單來搜尋匯入請求。可使用以下參數來讓您的搜尋更精準。",
-	"right-handle-import-interwiki": "處理跨 wiki 匯入傾印",
+	"right-handle-import-request-interwiki": "處理跨 wiki 匯入傾印",
 	"right-handle-import-requests": "處理使用者匯入傾印申請",
 	"right-request-import": "申請匯入",
 	"right-view-private-import-requests": "查看非公開匯入申請"

--- a/i18n/zh-hant.json
+++ b/i18n/zh-hant.json
@@ -9,10 +9,10 @@
 			"铁桶"
 		]
 	},
-	"action-handle-import-dump-interwiki": "處理跨 wiki 匯入傾印",
-	"action-handle-import-dump-requests": "處理使用者匯入申請",
-	"action-request-import-dump": "申請匯入",
-	"action-view-private-import-dump-requests": "檢視非公開匯入申請",
+	"action-handle-import-interwiki": "處理跨 wiki 匯入傾印",
+	"action-handle-import-requests": "處理使用者匯入申請",
+	"action-request-import": "申請匯入",
+	"action-view-private-import-requests": "檢視非公開匯入申請",
 	"echo-category-title-importdump-import-failed": "匯入傾印請求失敗",
 	"echo-category-title-importdump-new-request": "新的匯入傾印申請",
 	"echo-category-title-importdump-request-comment": "新增到匯入傾印申請的意見",
@@ -116,7 +116,7 @@
 	"importdump-usergroups-none": "無",
 	"importdumpprivate-log-header": "這是目標為非公開 wiki 的所有匯入申請及狀態更新的日誌。",
 	"importdumpprivate-log-name": "匯入申請非公開日誌",
-	"ipb-action-request-import-dump": "申請匯入",
+	"ipb-action-request-import": "申請匯入",
 	"log-action-filter-importdump": "操作類型：",
 	"log-action-filter-importdump-interwiki": "跨 wiki 表修改",
 	"log-action-filter-importdump-request": "提交新的申請",
@@ -139,8 +139,8 @@
 	"requestimportdumpqueue": "匯入申請佇列",
 	"requestimportdumpqueue-header": "搜尋匯入請求",
 	"requestimportdumpqueue-header-info": "您可以使用此表單來搜尋匯入請求。可使用以下參數來讓您的搜尋更精準。",
-	"right-handle-import-dump-interwiki": "處理跨 wiki 匯入傾印",
-	"right-handle-import-dump-requests": "處理使用者匯入傾印申請",
-	"right-request-import-dump": "申請匯入",
-	"right-view-private-import-dump-requests": "查看非公開匯入申請"
+	"right-handle-import-interwiki": "處理跨 wiki 匯入傾印",
+	"right-handle-import-requests": "處理使用者匯入傾印申請",
+	"right-request-import": "申請匯入",
+	"right-view-private-import-requests": "查看非公開匯入申請"
 }

--- a/includes/Hooks/Handlers/Main.php
+++ b/includes/Hooks/Handlers/Main.php
@@ -52,7 +52,7 @@ class Main implements
 			return;
 		}
 
-		$actions[ 'request-import-dump' ] = 200;
+		$actions[ 'request-import' ] = 200;
 	}
 
 	/**

--- a/includes/ImportDumpRequestViewer.php
+++ b/includes/ImportDumpRequestViewer.php
@@ -339,7 +339,7 @@ class ImportDumpRequestViewer implements ImportDumpStatus {
 
 			if (
 				!$this->importDumpRequestManager->getInterwikiPrefix() &&
-				$this->permissionManager->userHasRight( $user, 'handle-import-interwiki' )
+				$this->permissionManager->userHasRight( $user, 'handle-import-request-interwiki' )
 			) {
 				$source = $this->importDumpRequestManager->getSource();
 				$target = $this->importDumpRequestManager->getTarget();

--- a/includes/ImportDumpRequestViewer.php
+++ b/includes/ImportDumpRequestViewer.php
@@ -55,7 +55,7 @@ class ImportDumpRequestViewer implements ImportDumpStatus {
 		if (
 			$this->importDumpRequestManager->isPrivate() &&
 			$user->getName() !== $this->importDumpRequestManager->getRequester()->getName() &&
-			!$this->permissionManager->userHasRight( $user, 'view-private-import-dump-requests' )
+			!$this->permissionManager->userHasRight( $user, 'view-private-import-requests' )
 		) {
 			$this->context->getOutput()->addHTML(
 				Html::errorBox( $this->context->msg( 'importdump-private' )->escaped() )
@@ -141,7 +141,7 @@ class ImportDumpRequestViewer implements ImportDumpStatus {
 		}
 
 		if (
-			$this->permissionManager->userHasRight( $user, 'handle-import-dump-requests' ) ||
+			$this->permissionManager->userHasRight( $user, 'handle-import-requests' ) ||
 			$user->getActorId() === $this->importDumpRequestManager->getRequester()->getActorId()
 		) {
 			$formDescriptor += [
@@ -196,7 +196,7 @@ class ImportDumpRequestViewer implements ImportDumpStatus {
 			];
 		}
 
-		if ( $this->permissionManager->userHasRight( $user, 'handle-import-dump-requests' ) ) {
+		if ( $this->permissionManager->userHasRight( $user, 'handle-import-requests' ) ) {
 			$validRequest = true;
 			$status = $this->importDumpRequestManager->getStatus();
 
@@ -303,7 +303,7 @@ class ImportDumpRequestViewer implements ImportDumpStatus {
 				],
 			];
 
-			if ( $this->permissionManager->userHasRight( $user, 'view-private-import-dump-requests' ) ) {
+			if ( $this->permissionManager->userHasRight( $user, 'view-private-import-requests' ) ) {
 				$formDescriptor += [
 					'handle-private' => [
 						'type' => 'check',
@@ -339,7 +339,7 @@ class ImportDumpRequestViewer implements ImportDumpStatus {
 
 			if (
 				!$this->importDumpRequestManager->getInterwikiPrefix() &&
-				$this->permissionManager->userHasRight( $user, 'handle-import-dump-interwiki' )
+				$this->permissionManager->userHasRight( $user, 'handle-import-interwiki' )
 			) {
 				$source = $this->importDumpRequestManager->getSource();
 				$target = $this->importDumpRequestManager->getTarget();

--- a/includes/Jobs/ImportDumpNotifyJob.php
+++ b/includes/Jobs/ImportDumpNotifyJob.php
@@ -127,10 +127,10 @@ class ImportDumpNotifyJob extends Job
 
 		foreach ( $notifiedUsers as $receiver ) {
 			if (
-				!$receiver->isAllowed( 'handle-import-dump-requests' ) ||
+				!$receiver->isAllowed( 'handle-import-requests' ) ||
 				(
 					$this->importDumpRequestManager->isPrivate() &&
-					!$receiver->isAllowed( 'view-private-import-dump-requests' )
+					!$receiver->isAllowed( 'view-private-import-requests' )
 				)
 			) {
 				continue;

--- a/includes/Specials/SpecialRequestImportDump.php
+++ b/includes/Specials/SpecialRequestImportDump.php
@@ -66,7 +66,7 @@ class SpecialRequestImportDump extends FormSpecialPage
 		UserFactory $userFactory,
 		?CreateWikiHookRunner $createWikiHookRunner
 	) {
-		parent::__construct( 'RequestImportDump', 'request-import-dump' );
+		parent::__construct( 'RequestImportDump', 'request-import' );
 
 		$this->createWikiHookRunner = $createWikiHookRunner;
 		$this->dbLoadBalancerFactory = $dbLoadBalancerFactory;
@@ -370,10 +370,10 @@ class SpecialRequestImportDump extends FormSpecialPage
 
 		foreach ( $notifiedUsers as $receiver ) {
 			if (
-				!$receiver->isAllowed( 'handle-import-dump-requests' ) ||
+				!$receiver->isAllowed( 'handle-import-requests' ) ||
 				(
 					$this->getLogType( $target ) === 'importdumpprivate' &&
-					!$receiver->isAllowed( 'view-private-import-dump-requests' )
+					!$receiver->isAllowed( 'view-private-import-requests' )
 				)
 			) {
 				continue;
@@ -431,7 +431,7 @@ class SpecialRequestImportDump extends FormSpecialPage
 		if (
 			$block && (
 				$user->isBlockedFromUpload() ||
-				$block->appliesToRight( 'request-import-dump' )
+				$block->appliesToRight( 'request-import' )
 			)
 		) {
 			throw new UserBlockedError( $block );


### PR DESCRIPTION
In preparation for renaming ImportDump to RequestImport for a better name to later expand supported import options (such as ImportImages)