### PR TITLE
Prepare for 1.42 migration to ConnectionProvider

### DIFF
--- a/includes/ImportDumpRequestManager.php
+++ b/includes/ImportDumpRequestManager.php
@@ -24,8 +24,8 @@ use Miraheze\CreateWiki\RemoteWiki;
 use Miraheze\ImportDump\Jobs\ImportDumpJob;
 use RepoGroup;
 use stdClass;
+use Wikimedia\Rdbms\IConnectionProvider;
 use Wikimedia\Rdbms\IDatabase;
-use Wikimedia\Rdbms\ILBFactory;
 use Wikimedia\Rdbms\SelectQueryBuilder;
 
 class ImportDumpRequestManager {
@@ -55,7 +55,7 @@ class ImportDumpRequestManager {
 	/** @var ActorStoreFactory */
 	private $actorStoreFactory;
 
-	/** @var ILBFactory */
+	/** @var IConnectionProvider */
 	private $connectionProvider;
 
 	/** @var CreateWikiHookRunner|null */
@@ -91,7 +91,7 @@ class ImportDumpRequestManager {
 	/**
 	 * @param Config $config
 	 * @param ActorStoreFactory $actorStoreFactory
-	 * @param ILBFactory $connectionProvider
+	 * @param IConnectionProvider $connectionProvider
 	 * @param InterwikiLookup $interwikiLookup
 	 * @param JobQueueGroupFactory $jobQueueGroupFactory
 	 * @param LinkRenderer $linkRenderer
@@ -105,7 +105,7 @@ class ImportDumpRequestManager {
 	public function __construct(
 		Config $config,
 		ActorStoreFactory $actorStoreFactory,
-		ILBFactory $connectionProvider,
+		IConnectionProvider $connectionProvider,
 		InterwikiLookup $interwikiLookup,
 		JobQueueGroupFactory $jobQueueGroupFactory,
 		LinkRenderer $linkRenderer,

--- a/includes/ImportDumpRequestManager.php
+++ b/includes/ImportDumpRequestManager.php
@@ -24,7 +24,7 @@ use Miraheze\CreateWiki\RemoteWiki;
 use Miraheze\ImportDump\Jobs\ImportDumpJob;
 use RepoGroup;
 use stdClass;
-use Wikimedia\Rdbms\DBConnRef;
+use Wikimedia\Rdbms\IDatabase;
 use Wikimedia\Rdbms\ILBFactory;
 use Wikimedia\Rdbms\SelectQueryBuilder;
 
@@ -46,7 +46,7 @@ class ImportDumpRequestManager {
 	/** @var Config */
 	private $config;
 
-	/** @var DBConnRef */
+	/** @var IDatabase */
 	private $dbw;
 
 	/** @var int */
@@ -55,11 +55,11 @@ class ImportDumpRequestManager {
 	/** @var ActorStoreFactory */
 	private $actorStoreFactory;
 
+	/** @var ILBFactory */
+	private $connectionProvider;
+
 	/** @var CreateWikiHookRunner|null */
 	private $createWikiHookRunner;
-
-	/** @var ILBFactory */
-	private $dbLoadBalancerFactory;
 
 	/** @var InterwikiLookup */
 	private $interwikiLookup;
@@ -91,7 +91,7 @@ class ImportDumpRequestManager {
 	/**
 	 * @param Config $config
 	 * @param ActorStoreFactory $actorStoreFactory
-	 * @param ILBFactory $dbLoadBalancerFactory
+	 * @param ILBFactory $connectionProvider
 	 * @param InterwikiLookup $interwikiLookup
 	 * @param JobQueueGroupFactory $jobQueueGroupFactory
 	 * @param LinkRenderer $linkRenderer
@@ -105,7 +105,7 @@ class ImportDumpRequestManager {
 	public function __construct(
 		Config $config,
 		ActorStoreFactory $actorStoreFactory,
-		ILBFactory $dbLoadBalancerFactory,
+		ILBFactory $connectionProvider,
 		InterwikiLookup $interwikiLookup,
 		JobQueueGroupFactory $jobQueueGroupFactory,
 		LinkRenderer $linkRenderer,
@@ -120,8 +120,8 @@ class ImportDumpRequestManager {
 
 		$this->config = $config;
 		$this->actorStoreFactory = $actorStoreFactory;
+		$this->connectionProvider = $connectionProvider;
 		$this->createWikiHookRunner = $createWikiHookRunner;
-		$this->dbLoadBalancerFactory = $dbLoadBalancerFactory;
 		$this->interwikiLookup = $interwikiLookup;
 		$this->jobQueueGroupFactory = $jobQueueGroupFactory;
 		$this->linkRenderer = $linkRenderer;
@@ -139,13 +139,9 @@ class ImportDumpRequestManager {
 		$this->ID = $requestID;
 
 		$centralWiki = $this->options->get( 'ImportDumpCentralWiki' );
-		if ( $centralWiki ) {
-			$this->dbw = $this->dbLoadBalancerFactory->getMainLB(
-				$centralWiki
-			)->getConnection( DB_PRIMARY, [], $centralWiki );
-		} else {
-			$this->dbw = $this->dbLoadBalancerFactory->getMainLB()->getConnection( DB_PRIMARY );
-		}
+		$this->dbw = $this->connectionProvider->getPrimaryDatabase(
+			$centralWiki ?: false
+		);
 
 		$this->row = $this->dbw->newSelectQueryBuilder()
 			->table( 'import_requests' )
@@ -316,9 +312,9 @@ class ImportDumpRequestManager {
 	 * @return bool
 	 */
 	public function insertInterwikiPrefix( string $prefix, string $url, User $user ): bool {
-		$dbw = $this->dbLoadBalancerFactory->getMainLB(
+		$dbw = $this->connectionProvider->getPrimaryDatabase(
 			$this->getTarget()
-		)->getConnection( DB_PRIMARY, [], $this->getTarget() );
+		);
 
 		$dbw->newInsertQueryBuilder()
 			->insertInto( 'interwiki' )
@@ -368,9 +364,9 @@ class ImportDumpRequestManager {
 	 * @return string
 	 */
 	public function getInterwikiPrefix(): string {
-		$dbr = $this->dbLoadBalancerFactory->getMainLB(
+		$dbr = $this->connectionProvider->getReplicaDatabase(
 			$this->getTarget()
-		)->getConnection( DB_REPLICA, [], $this->getTarget() );
+		);
 
 		$sourceHost = parse_url( $this->getSource(), PHP_URL_HOST );
 		if ( !$sourceHost ) {
@@ -396,9 +392,9 @@ class ImportDumpRequestManager {
 			ExtensionRegistry::getInstance()->isLoaded( 'Interwiki' ) &&
 			$this->config->get( 'InterwikiCentralDB' )
 		) {
-			$dbr = $this->dbLoadBalancerFactory->getMainLB(
+			$dbr = $this->connectionProvider->getReplicaDatabase(
 				$this->config->get( 'InterwikiCentralDB' )
-			)->getConnection( DB_REPLICA, [], $this->config->get( 'InterwikiCentralDB' ) );
+			);
 
 			$row = $dbr->newSelectQueryBuilder()
 				->table( 'interwiki' )

--- a/includes/ImportDumpRequestQueuePager.php
+++ b/includes/ImportDumpRequestQueuePager.php
@@ -31,7 +31,7 @@ class ImportDumpRequestQueuePager extends TablePager
 	/**
 	 * @param Config $config
 	 * @param IContextSource $context
-	 * @param ILBFactory $dbLoadBalancerFactory
+	 * @param ILBFactory $connectionProvider
 	 * @param LinkRenderer $linkRenderer
 	 * @param UserFactory $userFactory
 	 * @param string $requester
@@ -41,7 +41,7 @@ class ImportDumpRequestQueuePager extends TablePager
 	public function __construct(
 		Config $config,
 		IContextSource $context,
-		ILBFactory $dbLoadBalancerFactory,
+		ILBFactory $connectionProvider,
 		LinkRenderer $linkRenderer,
 		UserFactory $userFactory,
 		string $requester,
@@ -51,13 +51,9 @@ class ImportDumpRequestQueuePager extends TablePager
 		parent::__construct( $context, $linkRenderer );
 
 		$centralWiki = $config->get( 'ImportDumpCentralWiki' );
-		if ( $centralWiki ) {
-			$this->mDb = $dbLoadBalancerFactory->getMainLB(
-				$centralWiki
-			)->getConnection( DB_REPLICA, [], $centralWiki );
-		} else {
-			$this->mDb = $dbLoadBalancerFactory->getMainLB()->getConnection( DB_REPLICA );
-		}
+		$this->mDb = $connectionProvider->getReplicaDatabase(
+			$centralWiki ?: false
+		);
 
 		$this->linkRenderer = $linkRenderer;
 		$this->userFactory = $userFactory;

--- a/includes/ImportDumpRequestQueuePager.php
+++ b/includes/ImportDumpRequestQueuePager.php
@@ -8,7 +8,7 @@ use MediaWiki\Linker\LinkRenderer;
 use MediaWiki\Pager\TablePager;
 use MediaWiki\SpecialPage\SpecialPage;
 use MediaWiki\User\UserFactory;
-use Wikimedia\Rdbms\ILBFactory;
+use Wikimedia\Rdbms\IConnectionProvider;
 
 class ImportDumpRequestQueuePager extends TablePager
 	implements ImportDumpStatus {
@@ -31,7 +31,7 @@ class ImportDumpRequestQueuePager extends TablePager
 	/**
 	 * @param Config $config
 	 * @param IContextSource $context
-	 * @param ILBFactory $connectionProvider
+	 * @param IConnectionProvider $connectionProvider
 	 * @param LinkRenderer $linkRenderer
 	 * @param UserFactory $userFactory
 	 * @param string $requester
@@ -41,7 +41,7 @@ class ImportDumpRequestQueuePager extends TablePager
 	public function __construct(
 		Config $config,
 		IContextSource $context,
-		ILBFactory $connectionProvider,
+		IConnectionProvider $connectionProvider,
 		LinkRenderer $linkRenderer,
 		UserFactory $userFactory,
 		string $requester,

--- a/includes/Jobs/ImportDumpJob.php
+++ b/includes/Jobs/ImportDumpJob.php
@@ -28,7 +28,7 @@ use RequestContext;
 use SiteStatsUpdate;
 use Throwable;
 use WikiImporterFactory;
-use Wikimedia\Rdbms\ILBFactory;
+use Wikimedia\Rdbms\IConnectionProvider;
 
 class ImportDumpJob extends Job
 	implements ImportDumpStatus {

--- a/includes/Jobs/ImportDumpJob.php
+++ b/includes/Jobs/ImportDumpJob.php
@@ -44,7 +44,7 @@ class ImportDumpJob extends Job
 	/** @var Config */
 	private $config;
 
-	/** @var ILBFactory */
+	/** @var IConnectionProvider */
 	private $connectionProvider;
 
 	/** @var JobQueueGroupFactory */
@@ -65,7 +65,7 @@ class ImportDumpJob extends Job
 	/**
 	 * @param array $params
 	 * @param ConfigFactory $configFactory
-	 * @param ILBFactory $connectionProvider
+	 * @param IConnectionProvider $connectionProvider
 	 * @param JobQueueGroupFactory $jobQueueGroupFactory
 	 * @param ImportDumpHookRunner $importDumpHookRunner
 	 * @param ImportDumpRequestManager $importDumpRequestManager
@@ -74,7 +74,7 @@ class ImportDumpJob extends Job
 	public function __construct(
 		array $params,
 		ConfigFactory $configFactory,
-		ILBFactory $connectionProvider,
+		IConnectionProvider $connectionProvider,
 		JobQueueGroupFactory $jobQueueGroupFactory,
 		ImportDumpHookRunner $importDumpHookRunner,
 		ImportDumpRequestManager $importDumpRequestManager,

--- a/includes/Jobs/ImportDumpJob.php
+++ b/includes/Jobs/ImportDumpJob.php
@@ -45,7 +45,7 @@ class ImportDumpJob extends Job
 	private $config;
 
 	/** @var ILBFactory */
-	private $dbLoadBalancerFactory;
+	private $connectionProvider;
 
 	/** @var JobQueueGroupFactory */
 	private $jobQueueGroupFactory;
@@ -65,7 +65,7 @@ class ImportDumpJob extends Job
 	/**
 	 * @param array $params
 	 * @param ConfigFactory $configFactory
-	 * @param ILBFactory $dbLoadBalancerFactory
+	 * @param ILBFactory $connectionProvider
 	 * @param JobQueueGroupFactory $jobQueueGroupFactory
 	 * @param ImportDumpHookRunner $importDumpHookRunner
 	 * @param ImportDumpRequestManager $importDumpRequestManager
@@ -74,7 +74,7 @@ class ImportDumpJob extends Job
 	public function __construct(
 		array $params,
 		ConfigFactory $configFactory,
-		ILBFactory $dbLoadBalancerFactory,
+		ILBFactory $connectionProvider,
 		JobQueueGroupFactory $jobQueueGroupFactory,
 		ImportDumpHookRunner $importDumpHookRunner,
 		ImportDumpRequestManager $importDumpRequestManager,
@@ -85,7 +85,7 @@ class ImportDumpJob extends Job
 		$this->requestID = $params['requestid'];
 		$this->username = $params['username'];
 
-		$this->dbLoadBalancerFactory = $dbLoadBalancerFactory;
+		$this->connectionProvider = $connectionProvider;
 		$this->jobQueueGroupFactory = $jobQueueGroupFactory;
 		$this->importDumpHookRunner = $importDumpHookRunner;
 		$this->importDumpRequestManager = $importDumpRequestManager;
@@ -99,7 +99,7 @@ class ImportDumpJob extends Job
 	 * @return bool
 	 */
 	public function run(): bool {
-		$dbw = $this->dbLoadBalancerFactory->getMainLB()->getMaintenanceConnectionRef( DB_PRIMARY );
+		$dbw = $this->connectionProvider->getPrimaryDatabase();
 
 		$this->importDumpRequestManager->fromID( $this->requestID );
 		$filePath = wfTempDir() . '/' . $this->importDumpRequestManager->getFileName();

--- a/includes/Specials/SpecialRequestImport.php
+++ b/includes/Specials/SpecialRequestImport.php
@@ -27,12 +27,12 @@ use UploadBase;
 use UploadFromUrl;
 use UploadStash;
 use UserBlockedError;
-use Wikimedia\Rdbms\ILBFactory;
+use Wikimedia\Rdbms\IConnectionProvider;
 
 class SpecialRequestImport extends FormSpecialPage
 	implements ImportDumpStatus {
 
-	/** @var ILBFactory */
+	/** @var IConnectionProvider */
 	private $connectionProvider;
 
 	/** @var CreateWikiHookRunner|null */
@@ -51,7 +51,7 @@ class SpecialRequestImport extends FormSpecialPage
 	private $userFactory;
 
 	/**
-	 * @param ILBFactory $connectionProvider
+	 * @param IConnectionProvider $connectionProvider
 	 * @param MimeAnalyzer $mimeAnalyzer
 	 * @param PermissionManager $permissionManager
 	 * @param RepoGroup $repoGroup
@@ -59,7 +59,7 @@ class SpecialRequestImport extends FormSpecialPage
 	 * @param ?CreateWikiHookRunner $createWikiHookRunner
 	 */
 	public function __construct(
-		ILBFactory $connectionProvider,
+		IConnectionProvider $connectionProvider,
 		MimeAnalyzer $mimeAnalyzer,
 		PermissionManager $permissionManager,
 		RepoGroup $repoGroup,

--- a/includes/Specials/SpecialRequestImport.php
+++ b/includes/Specials/SpecialRequestImport.php
@@ -31,7 +31,7 @@ use Wikimedia\Rdbms\ILBFactory;
 
 class SpecialRequestImport extends FormSpecialPage
 	implements ImportDumpStatus {
-		
+
 	/** @var ILBFactory */
 	private $connectionProvider;
 

--- a/includes/Specials/SpecialRequestImport.php
+++ b/includes/Specials/SpecialRequestImport.php
@@ -197,7 +197,7 @@ class SpecialRequestImport extends FormSpecialPage
 		}
 
 		$centralWiki = $this->getConfig()->get( 'ImportDumpCentralWiki' );
-		$dbw = $this->dbLoadBalancerFactory->getPrimaryDatabase(
+		$dbw = $this->connectionProvider->getPrimaryDatabase(
 			$centralWiki ?: false
 		);
 

--- a/includes/Specials/SpecialRequestImportQueue.php
+++ b/includes/Specials/SpecialRequestImportQueue.php
@@ -10,12 +10,12 @@ use Miraheze\ImportDump\ImportDumpRequestManager;
 use Miraheze\ImportDump\ImportDumpRequestQueuePager;
 use Miraheze\ImportDump\ImportDumpRequestViewer;
 use Miraheze\ImportDump\ImportDumpStatus;
-use Wikimedia\Rdbms\ILBFactory;
+use Wikimedia\Rdbms\IConnectionProvider;
 
 class SpecialRequestImportQueue extends SpecialPage
 	implements ImportDumpStatus {
 
-	/** @var ILBFactory */
+	/** @var IConnectionProvider */
 	private $connectionProvider;
 
 	/** @var ImportDumpRequestManager */
@@ -28,13 +28,13 @@ class SpecialRequestImportQueue extends SpecialPage
 	private $userFactory;
 
 	/**
-	 * @param ILBFactory $connectionProvider
+	 * @param IConnectionProvider $connectionProvider
 	 * @param ImportDumpRequestManager $importDumpRequestManager
 	 * @param PermissionManager $permissionManager
 	 * @param UserFactory $userFactory
 	 */
 	public function __construct(
-		ILBFactory $connectionProvider,
+		IConnectionProvider $connectionProvider,
 		ImportDumpRequestManager $importDumpRequestManager,
 		PermissionManager $permissionManager,
 		UserFactory $userFactory

--- a/includes/Specials/SpecialRequestImportQueue.php
+++ b/includes/Specials/SpecialRequestImportQueue.php
@@ -16,7 +16,7 @@ class SpecialRequestImportQueue extends SpecialPage
 	implements ImportDumpStatus {
 
 	/** @var ILBFactory */
-	private $dbLoadBalancerFactory;
+	private $connectionProvider;
 
 	/** @var ImportDumpRequestManager */
 	private $importDumpRequestManager;
@@ -28,20 +28,20 @@ class SpecialRequestImportQueue extends SpecialPage
 	private $userFactory;
 
 	/**
-	 * @param ILBFactory $dbLoadBalancerFactory
+	 * @param ILBFactory $connectionProvider
 	 * @param ImportDumpRequestManager $importDumpRequestManager
 	 * @param PermissionManager $permissionManager
 	 * @param UserFactory $userFactory
 	 */
 	public function __construct(
-		ILBFactory $dbLoadBalancerFactory,
+		ILBFactory $connectionProvider,
 		ImportDumpRequestManager $importDumpRequestManager,
 		PermissionManager $permissionManager,
 		UserFactory $userFactory
 	) {
 		parent::__construct( 'RequestImportQueue' );
 
-		$this->dbLoadBalancerFactory = $dbLoadBalancerFactory;
+		$this->connectionProvider = $connectionProvider;
 		$this->importDumpRequestManager = $importDumpRequestManager;
 		$this->permissionManager = $permissionManager;
 		$this->userFactory = $userFactory;
@@ -113,7 +113,7 @@ class SpecialRequestImportQueue extends SpecialPage
 		$pager = new ImportDumpRequestQueuePager(
 			$this->getConfig(),
 			$this->getContext(),
-			$this->dbLoadBalancerFactory,
+			$this->connectionProvider,
 			$this->getLinkRenderer(),
 			$this->userFactory,
 			$requester,


### PR DESCRIPTION
This should work on 1.41 also since we don't yet update the actual service it uses, this just prepares for it leaving all that is left is to change service to ConnectionProvider in 1.42, this also heads towards using a virtual domain here rather than a separate central wiki config.