### PR TITLE
Update for MediaWiki 1.42 and use virtual domain

### DIFF
--- a/.github/workflows/mediawiki-tests.yml
+++ b/.github/workflows/mediawiki-tests.yml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         include:
           # Latest MediaWiki stable - PHP 8.1
-          - mw: 'REL1_41'
+          - mw: 'REL1_42'
             php: 8.1
             php-docker: 81
             composer-test: true

--- a/extension.json
+++ b/extension.json
@@ -21,8 +21,7 @@
 		"Miraheze\\ImportDump\\": "includes/"
 	},
 	"TestAutoloadNamespaces": {
-		"Miraheze\\ImportDump\\Tests\\": "tests/phpunit/",
-		"Miraheze\\ImportDump\\Tests\\Unit\\": "tests/phpunit/unit/"
+		"Miraheze\\ImportDump\\Tests\\": "tests/phpunit/"
 	},
 	"JobClasses": {
 		"ImportDumpJob": {

--- a/extension.json
+++ b/extension.json
@@ -7,7 +7,7 @@
 	"license-name": "GPL-3.0-or-later",
 	"type": "specialpage",
 	"requires": {
-		"MediaWiki": ">= 1.41.0"
+		"MediaWiki": ">= 1.42.0"
 	},
 	"MessagesDirs": {
 		"ImportDump": [
@@ -29,7 +29,7 @@
 			"class": "Miraheze\\ImportDump\\Jobs\\ImportDumpJob",
 			"services": [
 				"ConfigFactory",
-				"DBLoadBalancerFactory",
+				"ConnectionProvider",
 				"JobQueueGroupFactory",
 				"ImportDumpHookRunner",
 				"ImportDumpRequestManager",
@@ -111,7 +111,7 @@
 		"RequestImport": {
 			"class": "Miraheze\\ImportDump\\Specials\\SpecialRequestImport",
 			"services": [
-				"DBLoadBalancerFactory",
+				"ConnectionProvider",
 				"MimeAnalyzer",
 				"PermissionManager",
 				"RepoGroup",
@@ -155,7 +155,7 @@
 		"Main": {
 			"class": "Miraheze\\ImportDump\\Hooks\\Handlers\\Main",
 			"services": [
-				"ConfigFactory"
+				"ConnectionProvider"
 			]
 		}
 	},
@@ -176,10 +176,6 @@
 		"remoteExtPath": "ImportDump/modules"
 	},
 	"config": {
-		"ImportDumpCentralWiki": {
-			"value": "",
-			"description": "If set, only allow users to request import dumps on this wiki."
-		},
 		"ImportDumpEnableAutomatedJob": {
 			"value": false,
 			"description": "Whether to enable a job where a reviewer just has to 'approve' an import and job handles everything else. You can use the ImportDumpJobGetFile hook to manipulate how the job gets the XML file."
@@ -226,6 +222,9 @@
 	},
 	"ServiceWiringFiles": [
 		"includes/ServiceWiring.php"
+	],
+	"DatabaseVirtualDomains": [
+		"virtual-importdump"
 	],
 	"manifest_version": 2
 }

--- a/includes/ConfigNames.php
+++ b/includes/ConfigNames.php
@@ -1,0 +1,23 @@
+<?php
+
+// phpcs:disable Generic.NamingConventions.UpperCaseConstantName.ClassConstantNotUpperCase
+namespace Miraheze\ImportDump;
+
+/**
+ * A class containing constants representing the names of configuration variables,
+ * to protect against typos.
+ */
+class ConfigNames {
+
+	public const EnableAutomatedJob = 'ImportDumpEnableAutomatedJob';
+
+	public const HelpUrl = 'ImportDumpHelpUrl';
+
+	public const InterwikiMap = 'ImportDumpInterwikiMap';
+
+	public const ScriptCommand = 'ImportDumpScriptCommand';
+
+	public const UsersNotifiedOnAllRequests = 'ImportDumpUsersNotifiedOnAllRequests';
+
+	public const UsersNotifiedOnFailedImports = 'ImportDumpUsersNotifiedOnFailedImports';
+}

--- a/includes/Hooks/Handlers/Installer.php
+++ b/includes/Hooks/Handlers/Installer.php
@@ -2,7 +2,7 @@
 
 namespace Miraheze\ImportDump\Hooks\Handlers;
 
-use DatabaseUpdater;
+use MediaWiki\Installer\DatabaseUpdater;
 use MediaWiki\Installer\Hook\LoadExtensionSchemaUpdatesHook;
 
 class Installer implements LoadExtensionSchemaUpdatesHook {

--- a/includes/Hooks/Handlers/Main.php
+++ b/includes/Hooks/Handlers/Main.php
@@ -45,7 +45,7 @@ class Main implements
 	 */
 	public function onGetAllBlockActions( &$actions ) {
 		$dbr = $this->connectionProvider->getReplicaDatabase( 'virtual-importdump' );
-		if ( !WikiMap::isCurrentWikiId( $dbr->getDBname() ?? '' ) ) {
+		if ( !WikiMap::isCurrentWikiDbDomain( $dbr->getDomainID() ) ) {
 			return;
 		}
 
@@ -66,7 +66,7 @@ class Main implements
 	 */
 	public function onBeforeCreateEchoEvent( &$notifications, &$notificationCategories, &$icons ) {
 		$dbr = $this->connectionProvider->getReplicaDatabase( 'virtual-importdump' );
-		if ( !WikiMap::isCurrentWikiId( $dbr->getDBname() ?? '' ) ) {
+		if ( !WikiMap::isCurrentWikiDbDomain( $dbr->getDomainID() ) ) {
 			return;
 		}
 

--- a/includes/Hooks/Handlers/Main.php
+++ b/includes/Hooks/Handlers/Main.php
@@ -3,8 +3,6 @@
 namespace Miraheze\ImportDump\Hooks\Handlers;
 
 use MediaWiki\Block\Hook\GetAllBlockActionsHook;
-use MediaWiki\Config\Config;
-use MediaWiki\Config\ConfigFactory;
 use MediaWiki\Extension\Notifications\AttributeManager;
 use MediaWiki\Extension\Notifications\UserLocator;
 use MediaWiki\Hook\LoginFormValidErrorMessagesHook;
@@ -14,6 +12,7 @@ use Miraheze\ImportDump\Notifications\EchoImportFailedPresentationModel;
 use Miraheze\ImportDump\Notifications\EchoNewRequestPresentationModel;
 use Miraheze\ImportDump\Notifications\EchoRequestCommentPresentationModel;
 use Miraheze\ImportDump\Notifications\EchoRequestStatusUpdatePresentationModel;
+use Wikimedia\Rdbms\IConnectionProvider;
 
 class Main implements
 	GetAllBlockActionsHook,
@@ -21,14 +20,14 @@ class Main implements
 	UserGetReservedNamesHook
 {
 
-	/** @var Config */
-	private $config;
+	/** @var IConnectionProvider */
+	private $connectionProvider;
 
 	/**
-	 * @param ConfigFactory $configFactory
+	 * @param IConnectionProvider $connectionProvider
 	 */
-	public function __construct( ConfigFactory $configFactory ) {
-		$this->config = $configFactory->makeConfig( 'ImportDump' );
+	public function __construct( IConnectionProvider $connectionProvider ) {
+		$this->connectionProvider = $connectionProvider;
 	}
 
 	/**
@@ -45,10 +44,8 @@ class Main implements
 	 * @param array &$actions
 	 */
 	public function onGetAllBlockActions( &$actions ) {
-		if (
-			$this->config->get( 'ImportDumpCentralWiki' ) &&
-			!WikiMap::isCurrentWikiId( $this->config->get( 'ImportDumpCentralWiki' ) )
-		) {
+		$dbr = $this->connectionProvider->getReplicaDatabase( 'virtual-importdump' );
+		if ( !WikiMap::isCurrentWikiId( $dbr->getDBname() ?? '' ) ) {
 			return;
 		}
 
@@ -68,10 +65,8 @@ class Main implements
 	 * @param array &$icons
 	 */
 	public function onBeforeCreateEchoEvent( &$notifications, &$notificationCategories, &$icons ) {
-		if (
-			$this->config->get( 'ImportDumpCentralWiki' ) &&
-			!WikiMap::isCurrentWikiId( $this->config->get( 'ImportDumpCentralWiki' ) )
-		) {
+		$dbr = $this->connectionProvider->getReplicaDatabase( 'virtual-importdump' );
+		if ( !WikiMap::isCurrentWikiId( $dbr->getDBname() ?? '' ) ) {
 			return;
 		}
 

--- a/includes/ImportDumpOOUIForm.php
+++ b/includes/ImportDumpOOUIForm.php
@@ -2,13 +2,13 @@
 
 namespace Miraheze\ImportDump;
 
+use MediaWiki\HTMLForm\OOUIHTMLForm;
 use OOUI\FieldsetLayout;
 use OOUI\HtmlSnippet;
 use OOUI\IndexLayout;
 use OOUI\PanelLayout;
 use OOUI\TabPanelLayout;
 use OOUI\Widget;
-use OOUIHTMLForm;
 use Xml;
 
 class ImportDumpOOUIForm extends OOUIHTMLForm {

--- a/includes/ImportDumpRequestManager.php
+++ b/includes/ImportDumpRequestManager.php
@@ -38,8 +38,8 @@ class ImportDumpRequestManager {
 	];
 
 	public const CONSTRUCTOR_OPTIONS = [
-		'ImportDumpInterwikiMap',
-		'ImportDumpScriptCommand',
+		ConfigNames::InterwikiMap,
+		ConfigNames::ScriptCommand,
 	];
 
 	/** @var Config */
@@ -401,14 +401,14 @@ class ImportDumpRequestManager {
 			}
 		}
 
-		if ( $this->options->get( 'ImportDumpInterwikiMap' ) ) {
+		if ( $this->options->get( ConfigNames::InterwikiMap ) ) {
 			$parsedSource = parse_url( $this->getSource(), PHP_URL_HOST ) ?: '';
 			$domain = explode( '.', $parsedSource )[1] ?? '';
 
 			if ( $domain ) {
 				$domain .= '.' . ( explode( '.', $parsedSource )[2] ?? '' );
-				if ( $this->options->get( 'ImportDumpInterwikiMap' )[$domain] ?? '' ) {
-					$domain = $this->options->get( 'ImportDumpInterwikiMap' )[$domain];
+				if ( $this->options->get( ConfigNames::InterwikiMap )[$domain] ?? '' ) {
+					$domain = $this->options->get( ConfigNames::InterwikiMap )[$domain];
 					$subdomain = explode( '.', $parsedSource )[0] ?? '';
 
 					if ( $subdomain ) {
@@ -425,7 +425,7 @@ class ImportDumpRequestManager {
 	 * @return string
 	 */
 	public function getCommand(): string {
-		$command = $this->options->get( 'ImportDumpScriptCommand' );
+		$command = $this->options->get( ConfigNames::ScriptCommand );
 
 		if ( !$this->getInterwikiPrefix() ) {
 			$command = preg_replace( '/--username-prefix=?/', '', $command );

--- a/includes/ImportDumpRequestQueuePager.php
+++ b/includes/ImportDumpRequestQueuePager.php
@@ -2,8 +2,7 @@
 
 namespace Miraheze\ImportDump;
 
-use IContextSource;
-use MediaWiki\Config\Config;
+use MediaWiki\Context\IContextSource;
 use MediaWiki\Linker\LinkRenderer;
 use MediaWiki\Pager\TablePager;
 use MediaWiki\SpecialPage\SpecialPage;
@@ -29,7 +28,6 @@ class ImportDumpRequestQueuePager extends TablePager
 	private $target;
 
 	/**
-	 * @param Config $config
 	 * @param IContextSource $context
 	 * @param IConnectionProvider $connectionProvider
 	 * @param LinkRenderer $linkRenderer
@@ -39,7 +37,6 @@ class ImportDumpRequestQueuePager extends TablePager
 	 * @param string $target
 	 */
 	public function __construct(
-		Config $config,
 		IContextSource $context,
 		IConnectionProvider $connectionProvider,
 		LinkRenderer $linkRenderer,
@@ -50,10 +47,7 @@ class ImportDumpRequestQueuePager extends TablePager
 	) {
 		parent::__construct( $context, $linkRenderer );
 
-		$centralWiki = $config->get( 'ImportDumpCentralWiki' );
-		$this->mDb = $connectionProvider->getReplicaDatabase(
-			$centralWiki ?: false
-		);
+		$this->mDb = $connectionProvider->getReplicaDatabase( 'virtual-importdump' );
 
 		$this->linkRenderer = $linkRenderer;
 		$this->userFactory = $userFactory;

--- a/includes/ImportDumpRequestViewer.php
+++ b/includes/ImportDumpRequestViewer.php
@@ -2,14 +2,14 @@
 
 namespace Miraheze\ImportDump;
 
-use HTMLForm;
-use IContextSource;
 use MediaWiki\Config\Config;
+use MediaWiki\Context\IContextSource;
 use MediaWiki\Html\Html;
+use MediaWiki\HTMLForm\HTMLForm;
 use MediaWiki\Linker\Linker;
 use MediaWiki\MainConfigNames;
+use MediaWiki\Message\Message;
 use MediaWiki\Permissions\PermissionManager;
-use MediaWiki\Status\Status;
 use MediaWiki\User\User;
 use MediaWiki\WikiMap\WikiMap;
 use UserNotLoggedIn;
@@ -446,11 +446,11 @@ class ImportDumpRequestViewer implements ImportDumpStatus {
 	/**
 	 * @param ?string $comment
 	 * @param array $alldata
-	 * @return string|bool
+	 * @return string|bool|Message
 	 */
 	public function isValidComment( ?string $comment, array $alldata ) {
 		if ( isset( $alldata['submit-comment'] ) && ( !$comment || ctype_space( $comment ) ) ) {
-			return Status::newFatal( 'htmlform-required' )->getMessage();
+			return $this->context->msg( 'htmlform-required' );
 		}
 
 		return true;
@@ -458,11 +458,11 @@ class ImportDumpRequestViewer implements ImportDumpStatus {
 
 	/**
 	 * @param ?string $target
-	 * @return string|bool
+	 * @return string|bool|Message
 	 */
 	public function isValidDatabase( ?string $target ) {
 		if ( !in_array( $target, $this->config->get( MainConfigNames::LocalDatabases ) ) ) {
-			return Status::newFatal( 'importdump-invalid-target' )->getMessage();
+			return $this->context->msg( 'importdump-invalid-target' );
 		}
 
 		return true;
@@ -470,11 +470,11 @@ class ImportDumpRequestViewer implements ImportDumpStatus {
 
 	/**
 	 * @param ?string $reason
-	 * @return string|bool
+	 * @return string|bool|Message
 	 */
 	public function isValidReason( ?string $reason ) {
 		if ( !$reason || ctype_space( $reason ) ) {
-			return Status::newFatal( 'htmlform-required' )->getMessage();
+			return $this->context->msg( 'htmlform-required' );
 		}
 
 		return true;
@@ -483,11 +483,11 @@ class ImportDumpRequestViewer implements ImportDumpStatus {
 	/**
 	 * @param ?string $prefix
 	 * @param array $alldata
-	 * @return string|bool
+	 * @return string|bool|Message
 	 */
 	public function isValidInterwikiPrefix( ?string $prefix, array $alldata ) {
 		if ( isset( $alldata['submit-interwiki'] ) && ( !$prefix || ctype_space( $prefix ) ) ) {
-			return Status::newFatal( 'htmlform-required' )->getMessage();
+			return $this->context->msg( 'htmlform-required' );
 		}
 
 		return true;
@@ -496,7 +496,7 @@ class ImportDumpRequestViewer implements ImportDumpStatus {
 	/**
 	 * @param ?string $url
 	 * @param array $alldata
-	 * @return string|bool
+	 * @return string|bool|Message
 	 */
 	public function isValidInterwikiUrl( ?string $url, array $alldata ) {
 		if ( !isset( $alldata['submit-interwiki'] ) ) {
@@ -504,14 +504,14 @@ class ImportDumpRequestViewer implements ImportDumpStatus {
 		}
 
 		if ( !$url || ctype_space( $url ) ) {
-			return Status::newFatal( 'htmlform-required' )->getMessage();
+			return $this->context->msg( 'htmlform-required' );
 		}
 
 		if (
 			!parse_url( $url, PHP_URL_SCHEME ) ||
 			!parse_url( $url, PHP_URL_HOST )
 		) {
-			return Status::newFatal( 'importdump-invalid-interwiki-url' )->getMessage();
+			return $this->context->msg( 'importdump-invalid-interwiki-url' );
 		}
 
 		return true;

--- a/includes/ImportDumpRequestViewer.php
+++ b/includes/ImportDumpRequestViewer.php
@@ -212,7 +212,7 @@ class ImportDumpRequestViewer implements ImportDumpStatus {
 					$this->context->msg( 'importdump-button-copy' )->text()
 				);
 
-				if ( $this->config->get( 'ImportDumpEnableAutomatedJob' ) && $status !== self::STATUS_FAILED ) {
+				if ( $this->config->get( ConfigNames::EnableAutomatedJob ) && $status !== self::STATUS_FAILED ) {
 					$fileInfo = '';
 				}
 
@@ -315,7 +315,7 @@ class ImportDumpRequestViewer implements ImportDumpStatus {
 				];
 			}
 
-			if ( $this->config->get( 'ImportDumpEnableAutomatedJob' ) ) {
+			if ( $this->config->get( ConfigNames::EnableAutomatedJob ) ) {
 				$formDescriptor += [
 					'handle-status' => [
 						'type' => 'select',
@@ -378,7 +378,7 @@ class ImportDumpRequestViewer implements ImportDumpStatus {
 				];
 			}
 
-			if ( $this->config->get( 'ImportDumpEnableAutomatedJob' ) ) {
+			if ( $this->config->get( ConfigNames::EnableAutomatedJob ) ) {
 				$validStatus = true;
 				if (
 					$status === self::STATUS_COMPLETE ||
@@ -734,7 +734,7 @@ class ImportDumpRequestViewer implements ImportDumpStatus {
 			}
 
 			if ( isset( $formData['handle-status'] ) ) {
-				if ( $this->config->get( 'ImportDumpEnableAutomatedJob' ) ) {
+				if ( $this->config->get( ConfigNames::EnableAutomatedJob ) ) {
 					$formData['handle-comment'] = '';
 				}
 

--- a/includes/Jobs/ImportDumpJob.php
+++ b/includes/Jobs/ImportDumpJob.php
@@ -17,7 +17,6 @@ use MediaWiki\MainConfigNames;
 use MediaWiki\Permissions\UltimateAuthority;
 use MediaWiki\SiteStats\SiteStatsInit;
 use MediaWiki\User\User;
-use MediaWiki\WikiMap\WikiMap;
 use MessageLocalizer;
 use Miraheze\ImportDump\Hooks\ImportDumpHookRunner;
 use Miraheze\ImportDump\ImportDumpRequestManager;
@@ -215,7 +214,7 @@ class ImportDumpJob extends Job
 	private function getLoggingWiki(): string {
 		return $this->connectionProvider
 			->getReplicaDatabase( 'virtual-importdump' )
-			->getDBname() ?? WikiMap::getCurrentWikiId();
+			->getDomainID();
 	}
 
 	/**

--- a/includes/Jobs/ImportDumpJob.php
+++ b/includes/Jobs/ImportDumpJob.php
@@ -9,6 +9,8 @@ use Job;
 use JobSpecification;
 use MediaWiki\Config\Config;
 use MediaWiki\Config\ConfigFactory;
+use MediaWiki\Context\RequestContext;
+use MediaWiki\Deferred\SiteStatsUpdate;
 use MediaWiki\Http\Telemetry;
 use MediaWiki\JobQueue\JobQueueGroupFactory;
 use MediaWiki\MainConfigNames;
@@ -24,8 +26,6 @@ use MWExceptionHandler;
 use RebuildRecentchanges;
 use RebuildTextIndex;
 use RefreshLinks;
-use RequestContext;
-use SiteStatsUpdate;
 use Throwable;
 use WikiImporterFactory;
 use Wikimedia\Rdbms\IConnectionProvider;
@@ -128,16 +128,9 @@ class ImportDumpJob extends Job
 		try {
 			$user = User::newSystemUser( 'ImportDump Extension', [ 'steal' => true ] );
 
-			if ( version_compare( MW_VERSION, '1.42', '>=' ) ) {
-				// @phan-suppress-next-line PhanParamTooMany
-				$importer = $this->wikiImporterFactory->getWikiImporter(
-					$importStreamSource->value, new UltimateAuthority( $user )
-				);
-			} else {
-				$importer = $this->wikiImporterFactory->getWikiImporter(
-					$importStreamSource->value
-				);
-			}
+			$importer = $this->wikiImporterFactory->getWikiImporter(
+				$importStreamSource->value, new UltimateAuthority( $user )
+			);
 
 			$importer->disableStatisticsUpdate();
 			$importer->setNoUpdates( true );
@@ -220,8 +213,9 @@ class ImportDumpJob extends Job
 	 * @return string
 	 */
 	private function getLoggingWiki(): string {
-		return $this->config->get( 'ImportDumpCentralWiki' ) ?:
-			WikiMap::getCurrentWikiId();
+		return $this->connectionProvider
+			->getReplicaDatabase( 'virtual-importdump' )
+			->getDBname() ?? WikiMap::getCurrentWikiId();
 	}
 
 	/**

--- a/includes/Jobs/ImportDumpNotifyJob.php
+++ b/includes/Jobs/ImportDumpNotifyJob.php
@@ -12,6 +12,7 @@ use MediaWiki\SpecialPage\SpecialPage;
 use MediaWiki\User\User;
 use MediaWiki\User\UserFactory;
 use MessageLocalizer;
+use Miraheze\ImportDump\ConfigNames;
 use Miraheze\ImportDump\ImportDumpRequestManager;
 use Miraheze\ImportDump\ImportDumpStatus;
 
@@ -116,7 +117,7 @@ class ImportDumpNotifyJob extends Job
 			array_map(
 				function ( string $userName ): ?User {
 					return $this->userFactory->newFromName( $userName );
-				}, $this->config->get( 'ImportDumpUsersNotifiedOnFailedImports' )
+				}, $this->config->get( ConfigNames::UsersNotifiedOnFailedImports )
 			)
 		);
 

--- a/includes/Jobs/ImportDumpNotifyJob.php
+++ b/includes/Jobs/ImportDumpNotifyJob.php
@@ -6,6 +6,7 @@ use ExtensionRegistry;
 use Job;
 use MediaWiki\Config\Config;
 use MediaWiki\Config\ConfigFactory;
+use MediaWiki\Context\RequestContext;
 use MediaWiki\Extension\Notifications\Model\Event;
 use MediaWiki\SpecialPage\SpecialPage;
 use MediaWiki\User\User;
@@ -13,7 +14,6 @@ use MediaWiki\User\UserFactory;
 use MessageLocalizer;
 use Miraheze\ImportDump\ImportDumpRequestManager;
 use Miraheze\ImportDump\ImportDumpStatus;
-use RequestContext;
 
 class ImportDumpNotifyJob extends Job
 	implements ImportDumpStatus {

--- a/includes/Notifications/EchoImportFailedPresentationModel.php
+++ b/includes/Notifications/EchoImportFailedPresentationModel.php
@@ -4,7 +4,7 @@ namespace Miraheze\ImportDump\Notifications;
 
 use MediaWiki\Extension\Notifications\DiscussionParser;
 use MediaWiki\Extension\Notifications\Formatters\EchoEventPresentationModel;
-use Message;
+use MediaWiki\Message\Message;
 
 class EchoImportFailedPresentationModel extends EchoEventPresentationModel {
 

--- a/includes/Notifications/EchoNewRequestPresentationModel.php
+++ b/includes/Notifications/EchoNewRequestPresentationModel.php
@@ -4,7 +4,7 @@ namespace Miraheze\ImportDump\Notifications;
 
 use MediaWiki\Extension\Notifications\DiscussionParser;
 use MediaWiki\Extension\Notifications\Formatters\EchoEventPresentationModel;
-use Message;
+use MediaWiki\Message\Message;
 
 class EchoNewRequestPresentationModel extends EchoEventPresentationModel {
 

--- a/includes/Notifications/EchoRequestCommentPresentationModel.php
+++ b/includes/Notifications/EchoRequestCommentPresentationModel.php
@@ -5,7 +5,7 @@ namespace Miraheze\ImportDump\Notifications;
 use MediaWiki\Extension\Notifications\DiscussionParser;
 use MediaWiki\Extension\Notifications\Formatters\EchoEventPresentationModel;
 use MediaWiki\Language\RawMessage;
-use Message;
+use MediaWiki\Message\Message;
 
 class EchoRequestCommentPresentationModel extends EchoEventPresentationModel {
 

--- a/includes/Notifications/EchoRequestStatusUpdatePresentationModel.php
+++ b/includes/Notifications/EchoRequestStatusUpdatePresentationModel.php
@@ -4,7 +4,7 @@ namespace Miraheze\ImportDump\Notifications;
 
 use MediaWiki\Extension\Notifications\Formatters\EchoEventPresentationModel;
 use MediaWiki\Language\RawMessage;
-use Message;
+use MediaWiki\Message\Message;
 
 class EchoRequestStatusUpdatePresentationModel extends EchoEventPresentationModel {
 

--- a/includes/ServiceWiring.php
+++ b/includes/ServiceWiring.php
@@ -1,6 +1,7 @@
 <?php
 
 use MediaWiki\Config\ServiceOptions;
+use MediaWiki\Context\RequestContext;
 use MediaWiki\MediaWikiServices;
 use Miraheze\ImportDump\Hooks\ImportDumpHookRunner;
 use Miraheze\ImportDump\ImportDumpRequestManager;
@@ -10,7 +11,7 @@ return [
 		return new ImportDumpRequestManager(
 			$services->getConfigFactory()->makeConfig( 'ImportDump' ),
 			$services->getActorStoreFactory(),
-			$services->getDBLoadBalancerFactory(),
+			$services->getConnectionProvider(),
 			$services->getInterwikiLookup(),
 			$services->getJobQueueGroupFactory(),
 			$services->getLinkRenderer(),

--- a/includes/Specials/SpecialRequestImport.php
+++ b/includes/Specials/SpecialRequestImport.php
@@ -85,7 +85,7 @@ class SpecialRequestImport extends FormSpecialPage
 		$this->setHeaders();
 
 		$dbr = $this->connectionProvider->getReplicaDatabase( 'virtual-importdump' );
-		if ( !WikiMap::isCurrentWikiId( $dbr->getDBname() ?? '' ) ) {
+		if ( !WikiMap::isCurrentWikiDbDomain( $dbr->getDomainID() ) ) {
 			throw new ErrorPageError( 'importdump-notcentral', 'importdump-notcentral-text' );
 		}
 

--- a/includes/Specials/SpecialRequestImport.php
+++ b/includes/Specials/SpecialRequestImport.php
@@ -9,6 +9,7 @@ use ManualLogEntry;
 use MediaWiki\Extension\Notifications\Model\Event;
 use MediaWiki\Html\Html;
 use MediaWiki\MainConfigNames;
+use MediaWiki\Message\Message;
 use MediaWiki\Permissions\PermissionManager;
 use MediaWiki\SpecialPage\FormSpecialPage;
 use MediaWiki\SpecialPage\SpecialPage;
@@ -16,7 +17,6 @@ use MediaWiki\Status\Status;
 use MediaWiki\User\User;
 use MediaWiki\User\UserFactory;
 use MediaWiki\WikiMap\WikiMap;
-use Message;
 use MimeAnalyzer;
 use Miraheze\CreateWiki\Hooks\CreateWikiHookRunner;
 use Miraheze\CreateWiki\RemoteWiki;
@@ -84,10 +84,8 @@ class SpecialRequestImport extends FormSpecialPage
 		$this->setParameter( $par );
 		$this->setHeaders();
 
-		if (
-			$this->getConfig()->get( 'ImportDumpCentralWiki' ) &&
-			!WikiMap::isCurrentWikiId( $this->getConfig()->get( 'ImportDumpCentralWiki' ) )
-		) {
+		$dbr = $this->connectionProvider->getReplicaDatabase( 'virtual-importdump' );
+		if ( !WikiMap::isCurrentWikiId( $dbr->getDBname() ?? '' ) ) {
 			throw new ErrorPageError( 'importdump-notcentral', 'importdump-notcentral-text' );
 		}
 
@@ -196,10 +194,7 @@ class SpecialRequestImport extends FormSpecialPage
 			return Status::newFatal( 'actionthrottledtext' );
 		}
 
-		$centralWiki = $this->getConfig()->get( 'ImportDumpCentralWiki' );
-		$dbw = $this->connectionProvider->getPrimaryDatabase(
-			$centralWiki ?: false
-		);
+		$dbw = $this->connectionProvider->getPrimaryDatabase( 'virtual-importdump' );
 
 		$duplicate = $dbw->newSelectQueryBuilder()
 			->table( 'import_requests' )
@@ -392,11 +387,11 @@ class SpecialRequestImport extends FormSpecialPage
 
 	/**
 	 * @param ?string $target
-	 * @return string|bool
+	 * @return string|bool|Message
 	 */
 	public function isValidDatabase( ?string $target ) {
 		if ( !in_array( $target, $this->getConfig()->get( MainConfigNames::LocalDatabases ) ) ) {
-			return Status::newFatal( 'importdump-invalid-target' )->getMessage();
+			return $this->msg( 'importdump-invalid-target' );
 		}
 
 		return true;
@@ -404,11 +399,11 @@ class SpecialRequestImport extends FormSpecialPage
 
 	/**
 	 * @param ?string $reason
-	 * @return string|bool
+	 * @return string|bool|Message
 	 */
 	public function isValidReason( ?string $reason ) {
 		if ( !$reason || ctype_space( $reason ) ) {
-			return Status::newFatal( 'htmlform-required' )->getMessage();
+			return $this->msg( 'htmlform-required' );
 		}
 
 		return true;

--- a/includes/Specials/SpecialRequestImport.php
+++ b/includes/Specials/SpecialRequestImport.php
@@ -20,6 +20,7 @@ use MediaWiki\WikiMap\WikiMap;
 use MimeAnalyzer;
 use Miraheze\CreateWiki\Hooks\CreateWikiHookRunner;
 use Miraheze\CreateWiki\RemoteWiki;
+use Miraheze\ImportDump\ConfigNames;
 use Miraheze\ImportDump\ImportDumpStatus;
 use PermissionsError;
 use RepoGroup;
@@ -91,8 +92,8 @@ class SpecialRequestImport extends FormSpecialPage
 
 		$this->checkPermissions();
 
-		if ( $this->getConfig()->get( 'ImportDumpHelpUrl' ) ) {
-			$this->getOutput()->addHelpLink( $this->getConfig()->get( 'ImportDumpHelpUrl' ), true );
+		if ( $this->getConfig()->get( ConfigNames::HelpUrl ) ) {
+			$this->getOutput()->addHelpLink( $this->getConfig()->get( ConfigNames::HelpUrl ), true );
 		}
 
 		$form = $this->getForm();
@@ -317,7 +318,7 @@ class SpecialRequestImport extends FormSpecialPage
 
 		if (
 			ExtensionRegistry::getInstance()->isLoaded( 'Echo' ) &&
-			$this->getConfig()->get( 'ImportDumpUsersNotifiedOnAllRequests' )
+			$this->getConfig()->get( ConfigNames::UsersNotifiedOnAllRequests )
 		) {
 			$this->sendNotifications( $data['reason'], $this->getUser()->getName(), $requestID, $data['target'] );
 		}
@@ -353,7 +354,7 @@ class SpecialRequestImport extends FormSpecialPage
 			array_map(
 				function ( string $userName ): ?User {
 					return $this->userFactory->newFromName( $userName );
-				}, $this->getConfig()->get( 'ImportDumpUsersNotifiedOnAllRequests' )
+				}, $this->getConfig()->get( ConfigNames::UsersNotifiedOnAllRequests )
 			)
 		);
 

--- a/includes/Specials/SpecialRequestImportQueue.php
+++ b/includes/Specials/SpecialRequestImportQueue.php
@@ -2,7 +2,7 @@
 
 namespace Miraheze\ImportDump\Specials;
 
-use HTMLForm;
+use MediaWiki\HTMLForm\HTMLForm;
 use MediaWiki\Permissions\PermissionManager;
 use MediaWiki\SpecialPage\SpecialPage;
 use MediaWiki\User\UserFactory;
@@ -111,7 +111,6 @@ class SpecialRequestImportQueue extends SpecialPage
 			->displayForm( false );
 
 		$pager = new ImportDumpRequestQueuePager(
-			$this->getConfig(),
 			$this->getContext(),
 			$this->connectionProvider,
 			$this->getLinkRenderer(),

--- a/tests/phpunit/SpecialRequestImportTest.php
+++ b/tests/phpunit/SpecialRequestImportTest.php
@@ -1,0 +1,305 @@
+<?php
+
+namespace Miraheze\ImportDump\Tests;
+
+use MediaWiki\Context\DerivativeContext;
+use MediaWiki\Context\RequestContext;
+use MediaWiki\Request\FauxRequest;
+use MediaWiki\Request\WebRequest;
+use MediaWiki\SpecialPage\SpecialPage;
+use MediaWiki\Status\Status;
+use MediaWiki\User\User;
+use MediaWiki\WikiMap\WikiMap;
+use MediaWikiIntegrationTestCase;
+use Miraheze\CreateWiki\Hooks\CreateWikiHookRunner;
+use Miraheze\ImportDump\Specials\SpecialRequestImport;
+use UserNotLoggedIn;
+use Wikimedia\TestingAccessWrapper;
+
+/**
+ * @group ImportDump
+ * @group Database
+ * @group Medium
+ * @coversDefaultClass \Miraheze\ImportDump\Specials\SpecialRequestImport
+ */
+class SpecialRequestImportTest extends MediaWikiIntegrationTestCase {
+
+	private SpecialRequestImport $specialRequestImport;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->setMwGlobals( 'wgVirtualDomainsMapping', [
+			'virtual-importdump' => [ 'db' => WikiMap::getCurrentWikiId() ],
+		] );
+
+		$this->specialRequestImport = new SpecialRequestImport(
+			$this->getServiceContainer()->getConnectionProvider(),
+			$this->getServiceContainer()->getMimeAnalyzer(),
+			$this->getServiceContainer()->getPermissionManager(),
+			$this->getServiceContainer()->getRepoGroup(),
+			$this->getServiceContainer()->getUserFactory(),
+			$this->createMock( CreateWikiHookRunner::class )
+		);
+	}
+
+	protected function tearDown(): void {
+		if ( file_exists( __DIR__ . '/testfile.xml' ) ) {
+			unlink( __DIR__ . '/testfile.xml' );
+		}
+
+		parent::tearDown();
+	}
+
+	/**
+	 * @covers ::__construct
+	 */
+	public function testConstructor() {
+		$this->assertInstanceOf( SpecialRequestImport::class, $this->specialRequestImport );
+	}
+
+	/**
+	 * @covers ::execute
+	 */
+	public function testExecute() {
+		$user = $this->getTestUser()->getUser();
+		$testContext = new DerivativeContext( $this->specialRequestImport->getContext() );
+
+		$testContext->setUser( $user );
+		$testContext->setTitle( SpecialPage::getTitleFor( 'RequestImport' ) );
+
+		$specialRequestImport = TestingAccessWrapper::newFromObject( $this->specialRequestImport );
+		$specialRequestImport->setContext( $testContext );
+
+		$this->assertNull( $specialRequestImport->execute( '' ) );
+	}
+
+	/**
+	 * @covers ::execute
+	 */
+	public function testExecuteLoggedOut() {
+		$this->expectException( UserNotLoggedIn::class );
+		$specialRequestImport = TestingAccessWrapper::newFromObject( $this->specialRequestImport );
+		$specialRequestImport->execute( '' );
+	}
+
+	/**
+	 * @dataProvider onSubmitDataProvider
+	 * @covers ::onSubmit
+	 */
+	public function testOnSubmit( array $data, bool $expectedSuccess ) {
+		if ( $data['UploadFile'] ) {
+			// Create a test file
+			file_put_contents( $data['UploadFile'], '<test>content</test>' );
+		}
+
+		$context = new DerivativeContext( $this->specialRequestImport->getContext() );
+		$user = $this->getMutableTestUser()->getUser();
+
+		$context->setUser( $user );
+		$this->setSessionUser( $user, $user->getRequest() );
+
+		$request = new FauxRequest(
+			[
+				'wpEditToken' => $user->getEditToken(),
+			],
+			true
+		);
+
+		$request->setUpload( 'wpUploadFile', [
+			'name' => basename( $data['UploadFile'] ),
+			'type' => 'application/xml',
+			'tmp_name' => $data['UploadFile'],
+			'error' => UPLOAD_ERR_OK,
+			'size' => filesize( $data['UploadFile'] ),
+		] );
+
+		$context->setRequest( $request );
+
+		$specialRequestImport = TestingAccessWrapper::newFromObject( $this->specialRequestImport );
+		$specialRequestImport->setContext( $context );
+
+		$status = $specialRequestImport->onSubmit( $data );
+		$this->assertInstanceOf( Status::class, $status );
+		if ( $expectedSuccess ) {
+			$this->assertStatusGood( $status );
+		} else {
+			$this->assertStatusError( 'empty-file', $status );
+		}
+	}
+
+	/**
+	 * Data provider for testOnSubmit
+	 *
+	 * @return array
+	 */
+	public function onSubmitDataProvider(): array {
+		return [
+			'valid data' => [
+				[
+					'source' => 'http://example.com',
+					'target' => 'wikidb',
+					'reason' => 'Test reason',
+					'UploadSourceType' => 'File',
+					'UploadFile' => __DIR__ . '/testfile.xml',
+				],
+				true,
+			],
+			'invalid data' => [
+				[
+					'source' => '',
+					'target' => '',
+					'reason' => '',
+					'UploadSourceType' => 'File',
+					'UploadFile' => '',
+				],
+				false,
+			],
+		];
+	}
+
+	/**
+	 * @covers ::onSubmit
+	 */
+	public function testOnSubmitDuplicate() {
+		$data = [
+			'source' => 'http://example.com',
+			'target' => 'wikidb',
+			'reason' => 'Test reason',
+			'UploadSourceType' => 'File',
+			'UploadFile' => __DIR__ . '/testfile.xml',
+		];
+
+		// Create a test file
+		file_put_contents( __DIR__ . '/testfile.xml', '<test>content</test>' );
+
+		$context = new DerivativeContext( $this->specialRequestImport->getContext() );
+		$user = $this->getMutableTestUser()->getUser();
+
+		$context->setUser( $user );
+		$this->setSessionUser( $user, $user->getRequest() );
+
+		$request = new FauxRequest(
+			[
+				'wpEditToken' => $user->getEditToken(),
+			],
+			true
+		);
+
+		$request->setUpload( 'wpUploadFile', [
+			'name' => 'testfile.xml',
+			'type' => 'application/xml',
+			'tmp_name' => __DIR__ . '/testfile.xml',
+			'error' => UPLOAD_ERR_OK,
+			'size' => filesize( __DIR__ . '/testfile.xml' ),
+		] );
+
+		$context->setRequest( $request );
+
+		$specialRequestImport = TestingAccessWrapper::newFromObject( $this->specialRequestImport );
+		$specialRequestImport->setContext( $context );
+
+		// First submission should succeed
+		$status = $specialRequestImport->onSubmit( $data );
+		$this->assertInstanceOf( Status::class, $status );
+		$this->assertStatusGood( $status );
+
+		// Second identical submission should fail
+		$status = $specialRequestImport->onSubmit( $data );
+		$this->assertInstanceOf( Status::class, $status );
+		$this->assertStatusError( 'importdump-duplicate-request', $status );
+	}
+
+	/**
+	 * @dataProvider isValidDatabaseDataProvider
+	 * @covers ::isValidDatabase
+	 */
+	public function testIsValidDatabase( ?string $target, $expected ) {
+		$result = $this->specialRequestImport->isValidDatabase( $target );
+		if ( is_string( $expected ) ) {
+			$this->assertSame( $expected, $result->getKey() );
+		} else {
+			$this->assertSame( $expected, $result );
+		}
+	}
+
+	/**
+	 * Data provider for testIsValidDatabase
+	 *
+	 * @return array
+	 */
+	public function isValidDatabaseDataProvider(): array {
+		return [
+			'valid database' => [ 'wikidb', true ],
+			'invalid database' => [ 'invalidwiki', 'importdump-invalid-target' ],
+		];
+	}
+
+	/**
+	 * @dataProvider isValidReasonDataProvider
+	 * @covers ::isValidReason
+	 */
+	public function testIsValidReason( ?string $reason, $expected ) {
+		$result = $this->specialRequestImport->isValidReason( $reason );
+		if ( is_string( $expected ) ) {
+			$this->assertSame( $expected, $result->getKey() );
+		} else {
+			$this->assertSame( $expected, $result );
+		}
+	}
+
+	/**
+	 * Data provider for testIsValidReason
+	 *
+	 * @return array
+	 */
+	public function isValidReasonDataProvider(): array {
+		return [
+			'valid reason' => [ 'Test reason', true ],
+			'invalid reason' => [ '', 'htmlform-required' ],
+		];
+	}
+
+	/**
+	 * @covers ::getFormFields
+	 */
+	public function testGetFormFields() {
+		$specialRequestImport = TestingAccessWrapper::newFromObject( $this->specialRequestImport );
+		$formFields = $specialRequestImport->getFormFields();
+		$this->assertIsArray( $formFields );
+		$this->assertArrayHasKey( 'source', $formFields );
+		$this->assertArrayHasKey( 'target', $formFields );
+		$this->assertArrayHasKey( 'reason', $formFields );
+	}
+
+	/**
+	 * @covers ::checkPermissions
+	 */
+	public function testCheckPermissions() {
+		$user = $this->getTestUser()->getUser();
+		$testContext = new DerivativeContext( $this->specialRequestImport->getContext() );
+
+		$testContext->setUser( $user );
+		$testContext->setTitle( SpecialPage::getTitleFor( 'RequestImport' ) );
+
+		$specialRequestImport = TestingAccessWrapper::newFromObject( $this->specialRequestImport );
+		$specialRequestImport->setContext( $testContext );
+		$this->assertNull( $specialRequestImport->checkPermissions() );
+	}
+
+	/**
+	 * @covers ::getLogType
+	 */
+	public function testGetLogType() {
+		$specialRequestImport = TestingAccessWrapper::newFromObject( $this->specialRequestImport );
+		$result = $specialRequestImport->getLogType( 'testwiki' );
+		$this->assertSame( 'importdump', $result );
+	}
+
+	private function setSessionUser( User $user, WebRequest $request ) {
+		RequestContext::getMain()->setUser( $user );
+		RequestContext::getMain()->setRequest( $request );
+		TestingAccessWrapper::newFromObject( $user )->mRequest = $request;
+		$request->getSession()->setUser( $user );
+	}
+}

--- a/tests/phpunit/Specials/SpecialRequestImportTest.php
+++ b/tests/phpunit/Specials/SpecialRequestImportTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Miraheze\ImportDump\Tests;
+namespace Miraheze\ImportDump\Tests\Specials;
 
 use Generator;
 use MediaWiki\Context\DerivativeContext;


### PR DESCRIPTION
Also adds new tests for SpecialRequestImport and ImportDumpRequestManager to ensure new DatabaseVirtualDomains handling. It also adds a new ConfigNames class to improve code standards and protect against typos.

This should not be merged until we want to drop MediaWiki 1.41 support.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Updated MediaWiki version requirement to 1.42.0 for better compatibility and performance.
  - Enhanced database connection handling for improved stability.

- **Bug Fixes**
  - Fixed import statements and dependencies to align with MediaWiki's updated structure.

- **Refactor**
  - Replaced `DBLoadBalancerFactory` with `ConnectionProvider` in various classes for more efficient database management.
  - Added `ConfigNames` to facilitate getting configuration options and to protect against typos.

- **Tests**
  - Added comprehensive test cases for `SpecialRequestImport` to ensure robust functionality and reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->