### PR TITLE
Prevent duplicate comments

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -18,7 +18,7 @@
 	"importdump-comment-given": "Comment given by $1:",
 	"importdump-comment-success": "Comment successfully added to this request.",
 	"importdump-desc": "An extension designed to automate user import requests.",
-	"importdump-duplicate-comment": "Unable to submit the same comment as your previous request again.",
+	"importdump-duplicate-comment": "Unable to submit the same comment as your previous request.",
 	"importdump-duplicate-request": "Unable to submit this request. It is too similar to an already open request.",
 	"importdump-edit-success": "Request successfully edited.",
 	"importdump-extensionname": "ImportDump",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -18,7 +18,7 @@
 	"importdump-comment-given": "Comment given by $1:",
 	"importdump-comment-success": "Comment successfully added to this request.",
 	"importdump-desc": "An extension designed to automate user import requests.",
-	"importdump-duplicate-comment": "Unable to submit the same comment as your last request again.",
+	"importdump-duplicate-comment": "Unable to submit the same comment as your previous request again.",
 	"importdump-duplicate-request": "Unable to submit this request. It is too similar to an already open request.",
 	"importdump-edit-success": "Request successfully edited.",
 	"importdump-extensionname": "ImportDump",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -18,6 +18,7 @@
 	"importdump-comment-given": "Comment given by $1:",
 	"importdump-comment-success": "Comment successfully added to this request.",
 	"importdump-desc": "An extension designed to automate user import requests.",
+	"importdump-duplicate-comment": "Unable to submit the same comment as your last request again",
 	"importdump-duplicate-request": "Unable to submit this request. It is too similar to an already open request.",
 	"importdump-edit-success": "Request successfully edited.",
 	"importdump-extensionname": "ImportDump",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -18,7 +18,7 @@
 	"importdump-comment-given": "Comment given by $1:",
 	"importdump-comment-success": "Comment successfully added to this request.",
 	"importdump-desc": "An extension designed to automate user import requests.",
-	"importdump-duplicate-comment": "Unable to submit the same comment as your last request again",
+	"importdump-duplicate-comment": "Unable to submit the same comment as your last request again.",
 	"importdump-duplicate-request": "Unable to submit this request. It is too similar to an already open request.",
 	"importdump-edit-success": "Request successfully edited.",
 	"importdump-extensionname": "ImportDump",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -18,7 +18,7 @@
 	"importdump-comment-given": "Comment given by $1:",
 	"importdump-comment-success": "Comment successfully added to this request.",
 	"importdump-desc": "An extension designed to automate user import requests.",
-	"importdump-duplicate-comment": "Unable to submit the same comment as your previous request.",
+	"importdump-duplicate-comment": "Unable to resubmit the same comment as your previous request.",
 	"importdump-duplicate-request": "Unable to submit this request. It is too similar to an already open request.",
 	"importdump-edit-success": "Request successfully edited.",
 	"importdump-extensionname": "ImportDump",

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -22,7 +22,7 @@
 	"importdump-comment-given": "Displayed if a custom comment is given. $1 is the handler's username.",
 	"importdump-comment-success": "Message displayed when a comment is successfully added to the request.",
 	"importdump-desc": "{{desc|name=ImportDump|url=https://github.com/miraheze/ImportDump}}",
-	"importdump-duplicate-comment": "Message displayed when the user attempts to submit the same comment as previous request again.",
+	"importdump-duplicate-comment": "Message displayed when the user attempts to resubmit the same comment as previous request.",
 	"importdump-duplicate-request": "Message displayed when user attempts to submit a request that is to similar to an existing open request.",
 	"importdump-edit-success": "Message displayed when the request is successfully edited.",
 	"importdump-extensionname": "{{name}}",

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -22,7 +22,7 @@
 	"importdump-comment-given": "Displayed if a custom comment is given. $1 is the handler's username.",
 	"importdump-comment-success": "Message displayed when a comment is successfully added to the request.",
 	"importdump-desc": "{{desc|name=ImportDump|url=https://github.com/miraheze/ImportDump}}",
-	"importdump-duplicate-comment": "Message displayed when the user attempts to submit the same comment as last request again.",
+	"importdump-duplicate-comment": "Message displayed when the user attempts to submit the same comment as previous request again.",
 	"importdump-duplicate-request": "Message displayed when user attempts to submit a request that is to similar to an existing open request.",
 	"importdump-edit-success": "Message displayed when the request is successfully edited.",
 	"importdump-extensionname": "{{name}}",

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -22,7 +22,7 @@
 	"importdump-comment-given": "Displayed if a custom comment is given. $1 is the handler's username.",
 	"importdump-comment-success": "Message displayed when a comment is successfully added to the request.",
 	"importdump-desc": "{{desc|name=ImportDump|url=https://github.com/miraheze/ImportDump}}",
-	"importdump-duplicate-comment": "Message displayed when the user attempts to resubmit the same comment as previous request.",
+	"importdump-duplicate-comment": "Message displayed when the user attempts to resubmit the same comment as the previous request.",
 	"importdump-duplicate-request": "Message displayed when user attempts to submit a request that is to similar to an existing open request.",
 	"importdump-edit-success": "Message displayed when the request is successfully edited.",
 	"importdump-extensionname": "{{name}}",

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -22,7 +22,7 @@
 	"importdump-comment-given": "Displayed if a custom comment is given. $1 is the handler's username.",
 	"importdump-comment-success": "Message displayed when a comment is successfully added to the request.",
 	"importdump-desc": "{{desc|name=ImportDump|url=https://github.com/miraheze/ImportDump}}",
-	"importdump-duplicate-comment": "Message displayed when the user attempts to resubmit the same comment as the user's previous request.",
+	"importdump-duplicate-comment": "Message displayed when the user attempts to resubmit the same comment as the their previous request.",
 	"importdump-duplicate-request": "Message displayed when user attempts to submit a request that is to similar to an existing open request.",
 	"importdump-edit-success": "Message displayed when the request is successfully edited.",
 	"importdump-extensionname": "{{name}}",

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -22,6 +22,7 @@
 	"importdump-comment-given": "Displayed if a custom comment is given. $1 is the handler's username.",
 	"importdump-comment-success": "Message displayed when a comment is successfully added to the request.",
 	"importdump-desc": "{{desc|name=ImportDump|url=https://github.com/miraheze/ImportDump}}",
+	"importdump-duplicate-comment": "Message displayed when the user attempts to submit the same comment as last request again.",
 	"importdump-duplicate-request": "Message displayed when user attempts to submit a request that is to similar to an existing open request.",
 	"importdump-edit-success": "Message displayed when the request is successfully edited.",
 	"importdump-extensionname": "{{name}}",

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -22,7 +22,7 @@
 	"importdump-comment-given": "Displayed if a custom comment is given. $1 is the handler's username.",
 	"importdump-comment-success": "Message displayed when a comment is successfully added to the request.",
 	"importdump-desc": "{{desc|name=ImportDump|url=https://github.com/miraheze/ImportDump}}",
-	"importdump-duplicate-comment": "Message displayed when the user attempts to resubmit the same comment as the previous request.",
+	"importdump-duplicate-comment": "Message displayed when the user attempts to resubmit the same comment as the user's previous request.",
 	"importdump-duplicate-request": "Message displayed when user attempts to submit a request that is to similar to an existing open request.",
 	"importdump-edit-success": "Message displayed when the request is successfully edited.",
 	"importdump-extensionname": "{{name}}",

--- a/includes/ImportDumpRequestManager.php
+++ b/includes/ImportDumpRequestManager.php
@@ -13,7 +13,6 @@ use MediaWiki\Interwiki\InterwikiLookup;
 use MediaWiki\JobQueue\JobQueueGroupFactory;
 use MediaWiki\Linker\LinkRenderer;
 use MediaWiki\SpecialPage\SpecialPage;
-use MediaWiki\Status\Status;
 use MediaWiki\User\ActorStoreFactory;
 use MediaWiki\User\User;
 use MediaWiki\User\UserFactory;
@@ -162,24 +161,8 @@ class ImportDumpRequestManager {
 	/**
 	 * @param string $comment
 	 * @param User $user
-	 * @return Status
 	 */
-	public function addComment( string $comment, User $user ): Status {
-		$duplicate = $this->dbw->newSelectQueryBuilder()
-			->table( 'import_request_comments' )
-			->field( '*' )
-			->where( [
-				'request_id' => $this->ID,
-				'request_comment_text' => $comment,
-				'request_comment_actor' => $user->getActorId(),
-			] )
-			->caller( __METHOD__ )
-			->fetchRow();
-
-		if ( (bool)$duplicate ) {
-			return Status::newFatal( 'importdump-duplicate-comment' );
-		}
-
+	public function addComment( string $comment, User $user ) {
 		$this->dbw->newInsertQueryBuilder()
 			->insertInto( 'import_request_comments' )
 			->row( [
@@ -197,8 +180,6 @@ class ImportDumpRequestManager {
 		) {
 			$this->sendNotification( $comment, 'importdump-request-comment', $user );
 		}
-
-		return Status::newGood();
 	}
 
 	/**

--- a/includes/ImportDumpRequestManager.php
+++ b/includes/ImportDumpRequestManager.php
@@ -13,6 +13,7 @@ use MediaWiki\Interwiki\InterwikiLookup;
 use MediaWiki\JobQueue\JobQueueGroupFactory;
 use MediaWiki\Linker\LinkRenderer;
 use MediaWiki\SpecialPage\SpecialPage;
+use MediaWiki\Status\Status;
 use MediaWiki\User\ActorStoreFactory;
 use MediaWiki\User\User;
 use MediaWiki\User\UserFactory;
@@ -23,7 +24,6 @@ use Miraheze\CreateWiki\Hooks\CreateWikiHookRunner;
 use Miraheze\CreateWiki\RemoteWiki;
 use Miraheze\ImportDump\Jobs\ImportDumpJob;
 use RepoGroup;
-use StatusValue;
 use stdClass;
 use Wikimedia\Rdbms\IConnectionProvider;
 use Wikimedia\Rdbms\IDatabase;
@@ -162,9 +162,9 @@ class ImportDumpRequestManager {
 	/**
 	 * @param string $comment
 	 * @param User $user
-	 * @return StatusValue
+	 * @return Status
 	 */
-	public function addComment( string $comment, User $user ): StatusValue {
+	public function addComment( string $comment, User $user ): Status {
 		$duplicate = $this->dbw->newSelectQueryBuilder()
 			->table( 'import_request_comments' )
 			->field( '*' )
@@ -177,7 +177,7 @@ class ImportDumpRequestManager {
 			->fetchRow();
 
 		if ( (bool)$duplicate ) {
-			return StatusValue::newFatal( 'importdump-duplicate-comment' );
+			return Status::newFatal( 'importdump-duplicate-comment' );
 		}
 
 		$this->dbw->newInsertQueryBuilder()
@@ -198,7 +198,7 @@ class ImportDumpRequestManager {
 			$this->sendNotification( $comment, 'importdump-request-comment', $user );
 		}
 
-		return StatusValue::newGood();
+		return Status::newGood();
 	}
 
 	/**

--- a/includes/ImportDumpRequestViewer.php
+++ b/includes/ImportDumpRequestViewer.php
@@ -567,9 +567,13 @@ class ImportDumpRequestViewer implements ImportDumpStatus {
 		$out = $form->getContext()->getOutput();
 
 		if ( isset( $formData['submit-comment'] ) ) {
-			$this->importDumpRequestManager->addComment( $formData['comment'], $user );
-			$out->addHTML( Html::successBox( $this->context->msg( 'importdump-comment-success' )->escaped() ) );
+			$status = $this->importDumpRequestManager->addComment( $formData['comment'], $user );
+			if ( $status->isGood() ) {
+				$out->addHTML( Html::successBox( $this->context->msg( 'importdump-comment-success' )->escaped() ) );
+				return;
+			}
 
+			$out->addHTML( Html::errorBox( $status->getMessage() ) );
 			return;
 		}
 

--- a/includes/ImportDumpRequestViewer.php
+++ b/includes/ImportDumpRequestViewer.php
@@ -54,6 +54,7 @@ class ImportDumpRequestViewer implements ImportDumpStatus {
 	 */
 	public function getFormDescriptor(): array {
 		$user = $this->context->getUser();
+		$this->formId = bin2hex( random_bytes( 16 ) );
 
 		if (
 			$this->importDumpRequestManager->isPrivate() &&
@@ -530,7 +531,6 @@ class ImportDumpRequestViewer implements ImportDumpStatus {
 	 */
 	public function getForm( int $requestID ): ?ImportDumpOOUIForm {
 		$this->importDumpRequestManager->fromID( $requestID );
-		$this->formId = bin2hex( random_bytes( 16 ) );
 		$out = $this->context->getOutput();
 
 		if ( $requestID === 0 || !$this->importDumpRequestManager->exists() ) {

--- a/includes/ImportDumpRequestViewer.php
+++ b/includes/ImportDumpRequestViewer.php
@@ -568,8 +568,8 @@ class ImportDumpRequestViewer implements ImportDumpStatus {
 		$session = $form->getRequest()->getSession();
 
 		if ( isset( $formData['submit-comment'] ) ) {
-			if ( $session->get( 'submittedcomment' ) !== $formData['comment'] ) {
-				$session->set( 'submittedcomment', $formData['comment'] );
+			if ( $session->get( 'posted_comment' ) !== $formData['comment'] ) {
+				$session->set( 'posted_comment', $formData['comment'] );
 				$this->importDumpRequestManager->addComment( $formData['comment'], $user );
 				$out->addHTML( Html::successBox( $this->context->msg( 'importdump-comment-success' )->escaped() ) );
 				return;
@@ -579,7 +579,7 @@ class ImportDumpRequestViewer implements ImportDumpStatus {
 			return;
 		}
 
-		$session->remove( 'submittedcomment' );
+		$session->remove( 'posted_comment' );
 
 		if ( isset( $formData['submit-edit'] ) ) {
 			$this->importDumpRequestManager->startAtomic( __METHOD__ );

--- a/includes/ImportDumpRequestViewer.php
+++ b/includes/ImportDumpRequestViewer.php
@@ -568,6 +568,14 @@ class ImportDumpRequestViewer implements ImportDumpStatus {
 		$request = $form->getRequest();
 		$session = $request->getSession();
 
+		$token = $request->getVal( 'wpEditToken' );
+		$userToken = $form->getContext()->getCsrfTokenSet();
+
+		if ( !$userToken->matchToken( $token ) ) {
+			$out->addHTML( Html::errorBox( 'TODO' ) );
+			return;
+		}
+
 		if ( isset( $formData['submit-comment'] ) ) {
 			if ( $request->wasPosted() && !$session->get( 'alreadysubmitted' ) ) {
 				$session->set( 'alreadysubmitted', true );

--- a/includes/ImportDumpRequestViewer.php
+++ b/includes/ImportDumpRequestViewer.php
@@ -568,8 +568,8 @@ class ImportDumpRequestViewer implements ImportDumpStatus {
 		$session = $form->getRequest()->getSession();
 
 		if ( isset( $formData['submit-comment'] ) ) {
-			if ( $session->get( 'last_posted_comment' ) !== $formData['comment'] ) {
-				$session->set( 'last_posted_comment', $formData['comment'] );
+			if ( $session->get( 'previous_posted_comment' ) !== $formData['comment'] ) {
+				$session->set( 'previous_posted_comment', $formData['comment'] );
 				$this->importDumpRequestManager->addComment( $formData['comment'], $user );
 				$out->addHTML( Html::successBox( $this->context->msg( 'importdump-comment-success' )->escaped() ) );
 				return;
@@ -579,7 +579,7 @@ class ImportDumpRequestViewer implements ImportDumpStatus {
 			return;
 		}
 
-		$session->remove( 'last_posted_comment' );
+		$session->remove( 'previous_posted_comment' );
 
 		if ( isset( $formData['submit-edit'] ) ) {
 			$this->importDumpRequestManager->startAtomic( __METHOD__ );

--- a/includes/ImportDumpRequestViewer.php
+++ b/includes/ImportDumpRequestViewer.php
@@ -569,11 +569,21 @@ class ImportDumpRequestViewer implements ImportDumpStatus {
 		}
 
 		$out = $form->getContext()->getOutput();
+		$request = $form->getRequest();
+		$session = $request->getSession();
 
 		if ( isset( $formData['submit-comment'] ) ) {
-			$this->importDumpRequestManager->addComment( $formData['comment'], $user );
-			$out->addHTML( Html::successBox( $this->context->msg( 'importdump-comment-success' )->escaped() ) );
+			if ( $request->wasPosted() && !$session->get( 'alreadysubmitted' ) ) {
+				$session->set( 'alreadysubmitted', true );
+				$this->importDumpRequestManager->addComment( $formData['comment'], $user );
+				$out->addHTML( Html::successBox( $this->context->msg( 'importdump-comment-success' )->escaped() ) );
+				return;
+			}
+
+			$session->remove( 'alreadysubmitted' );
 			unset( $_POST );
+
+			$out->addHTML( Html::errorBox( 'TODO' ) );
 			return;
 		}
 

--- a/includes/ImportDumpRequestViewer.php
+++ b/includes/ImportDumpRequestViewer.php
@@ -568,8 +568,8 @@ class ImportDumpRequestViewer implements ImportDumpStatus {
 		$session = $form->getRequest()->getSession();
 
 		if ( isset( $formData['submit-comment'] ) ) {
-			if ( $session->get( 'posted_comment' ) !== $formData['comment'] ) {
-				$session->set( 'posted_comment', $formData['comment'] );
+			if ( $session->get( 'last_posted_comment' ) !== $formData['comment'] ) {
+				$session->set( 'last_posted_comment', $formData['comment'] );
 				$this->importDumpRequestManager->addComment( $formData['comment'], $user );
 				$out->addHTML( Html::successBox( $this->context->msg( 'importdump-comment-success' )->escaped() ) );
 				return;
@@ -579,7 +579,7 @@ class ImportDumpRequestViewer implements ImportDumpStatus {
 			return;
 		}
 
-		$session->remove( 'posted_comment' );
+		$session->remove( 'last_posted_comment' );
 
 		if ( isset( $formData['submit-edit'] ) ) {
 			$this->importDumpRequestManager->startAtomic( __METHOD__ );

--- a/includes/ImportDumpRequestViewer.php
+++ b/includes/ImportDumpRequestViewer.php
@@ -47,8 +47,6 @@ class ImportDumpRequestViewer implements ImportDumpStatus {
 		$this->context = $context;
 		$this->importDumpRequestManager = $importDumpRequestManager;
 		$this->permissionManager = $permissionManager;
-
-		$this->formId = bin2hex( random_bytes( 16 ) );
 	}
 
 	/**
@@ -532,6 +530,7 @@ class ImportDumpRequestViewer implements ImportDumpStatus {
 	 */
 	public function getForm( int $requestID ): ?ImportDumpOOUIForm {
 		$this->importDumpRequestManager->fromID( $requestID );
+		$this->formId = bin2hex( random_bytes( 16 ) );
 		$out = $this->context->getOutput();
 
 		if ( $requestID === 0 || !$this->importDumpRequestManager->exists() ) {

--- a/includes/ImportDumpRequestViewer.php
+++ b/includes/ImportDumpRequestViewer.php
@@ -579,6 +579,8 @@ class ImportDumpRequestViewer implements ImportDumpStatus {
 			return;
 		}
 
+		$session->remove( 'submittedcomment' );
+
 		if ( isset( $formData['submit-edit'] ) ) {
 			$this->importDumpRequestManager->startAtomic( __METHOD__ );
 

--- a/includes/ImportDumpRequestViewer.php
+++ b/includes/ImportDumpRequestViewer.php
@@ -28,9 +28,6 @@ class ImportDumpRequestViewer implements ImportDumpStatus {
 	/** @var PermissionManager */
 	private $permissionManager;
 
-	/** @var string */
-	private $formId;
-
 	/**
 	 * @param Config $config
 	 * @param IContextSource $context
@@ -54,7 +51,6 @@ class ImportDumpRequestViewer implements ImportDumpStatus {
 	 */
 	public function getFormDescriptor(): array {
 		$user = $this->context->getUser();
-		$this->formId = bin2hex( random_bytes( 16 ) );
 
 		if (
 			$this->importDumpRequestManager->isPrivate() &&
@@ -575,13 +571,9 @@ class ImportDumpRequestViewer implements ImportDumpStatus {
 		$out = $form->getContext()->getOutput();
 
 		if ( isset( $formData['submit-comment'] ) ) {
-			if ( $formData['form-id'] === $this->formId ) {
-				$this->importDumpRequestManager->addComment( $formData['comment'], $user );
-				$out->addHTML( Html::successBox( $this->context->msg( 'importdump-comment-success' )->escaped() ) );
-				return;
-			}
-
-			$out->addHTML( Html::errorBox( 'TODO' ) );
+			$this->importDumpRequestManager->addComment( $formData['comment'], $user );
+			$out->addHTML( Html::successBox( $this->context->msg( 'importdump-comment-success' )->escaped() ) );
+			unset( $_POST );
 			return;
 		}
 

--- a/includes/ImportDumpRequestViewer.php
+++ b/includes/ImportDumpRequestViewer.php
@@ -145,10 +145,6 @@ class ImportDumpRequestViewer implements ImportDumpStatus {
 			$user->getActorId() === $this->importDumpRequestManager->getRequester()->getActorId()
 		) {
 			$formDescriptor += [
-				'form-id' => [
-					'type' => 'hidden',
-					'default' => $this->formId,
-				],
 				'comment' => [
 					'type' => 'textarea',
 					'rows' => 4,

--- a/includes/ImportDumpRequestViewer.php
+++ b/includes/ImportDumpRequestViewer.php
@@ -577,14 +577,14 @@ class ImportDumpRequestViewer implements ImportDumpStatus {
 		}
 
 		if ( isset( $formData['submit-comment'] ) ) {
-			if ( $request->wasPosted() && !$session->get( 'alreadysubmitted' ) ) {
+			if ( $request->wasPosted() && $session->get( 'alreadysubmitted' ) === false ) {
 				$session->set( 'alreadysubmitted', true );
 				$this->importDumpRequestManager->addComment( $formData['comment'], $user );
 				$out->addHTML( Html::successBox( $this->context->msg( 'importdump-comment-success' )->escaped() ) );
 				return;
 			}
 
-			$session->remove( 'alreadysubmitted' );
+			$session->set( 'alreadysubmitted', false );
 
 			$out->addHTML( Html::errorBox( 'TODO' ) );
 			return;

--- a/includes/ImportDumpRequestViewer.php
+++ b/includes/ImportDumpRequestViewer.php
@@ -569,19 +569,15 @@ class ImportDumpRequestViewer implements ImportDumpStatus {
 		}
 
 		$out = $form->getContext()->getOutput();
-		$request = $form->getRequest();
-		$session = $request->getSession();
+		$session = $form->getRequest()->getSession();
 
 		if ( isset( $formData['submit-comment'] ) ) {
-			if ( $request->wasPosted() && !$session->get( 'alreadysubmitted' ) ) {
-				$session->set( 'alreadysubmitted', true );
+			if ( $session->get( 'submittedcomment' ) !== $formData['comment'] ) {
+				$session->set( 'submittedcomment', $formData['comment'] );
 				$this->importDumpRequestManager->addComment( $formData['comment'], $user );
 				$out->addHTML( Html::successBox( $this->context->msg( 'importdump-comment-success' )->escaped() ) );
 				return;
 			}
-
-			$session->remove( 'alreadysubmitted' );
-			unset( $_POST );
 
 			$out->addHTML( Html::errorBox( 'TODO' ) );
 			return;

--- a/includes/ImportDumpRequestViewer.php
+++ b/includes/ImportDumpRequestViewer.php
@@ -565,15 +565,20 @@ class ImportDumpRequestViewer implements ImportDumpStatus {
 		}
 
 		$out = $form->getContext()->getOutput();
+		$request = $form->getRequest();
+		$session = $request->getSession();
 
 		if ( isset( $formData['submit-comment'] ) ) {
-			$status = $this->importDumpRequestManager->addComment( $formData['comment'], $user );
-			if ( $status->isGood() ) {
+			if ( $request->wasPosted() && !$session->get( 'alreadysubmitted' ) ) {
+				$session->set( 'alreadysubmitted', true );
+				$this->importDumpRequestManager->addComment( $formData['comment'], $user );
 				$out->addHTML( Html::successBox( $this->context->msg( 'importdump-comment-success' )->escaped() ) );
 				return;
 			}
 
-			$out->addHTML( Html::errorBox( $status->getMessage() ) );
+			$session->remove( 'alreadysubmitted' );
+
+			$out->addHTML( Html::errorBox( 'TODO' ) );
 			return;
 		}
 

--- a/includes/ImportDumpRequestViewer.php
+++ b/includes/ImportDumpRequestViewer.php
@@ -575,7 +575,7 @@ class ImportDumpRequestViewer implements ImportDumpStatus {
 				return;
 			}
 
-			$out->addHTML( Html::errorBox( 'TODO' ) );
+			$out->addHTML( Html::errorBox( $this->context->msg( 'importdump-duplicate-comment' )->escaped() ) );
 			return;
 		}
 

--- a/includes/ImportDumpRequestViewer.php
+++ b/includes/ImportDumpRequestViewer.php
@@ -577,14 +577,13 @@ class ImportDumpRequestViewer implements ImportDumpStatus {
 		}
 
 		if ( isset( $formData['submit-comment'] ) ) {
+			$session->set( 'alreadysubmitted', false );
 			if ( $request->wasPosted() && $session->get( 'alreadysubmitted' ) === false ) {
 				$session->set( 'alreadysubmitted', true );
 				$this->importDumpRequestManager->addComment( $formData['comment'], $user );
 				$out->addHTML( Html::successBox( $this->context->msg( 'importdump-comment-success' )->escaped() ) );
 				return;
 			}
-
-			$session->set( 'alreadysubmitted', false );
 
 			$out->addHTML( Html::errorBox( 'TODO' ) );
 			return;


### PR DESCRIPTION
~~This will prevent the same exact comment on the same exact request from the same exact user.~~

~~However, it could technically have the side affect of stopping intentionally duplicate comments, IE an import fails and you start it again, the same boilerplate comment from the extension would be used, or if a user has a boilerplate comment they use and use the same comment on the same request, it would prevent that from submitting as well.~~

~~We may be able to prevent this with three potential solutions:~~
* ~~checking the comment timestamp and only prevent if the same within X time~~
* ~~use rate limiting and only allow IE 1 comment per user every X minutes (regardless of request or if it is the same comment). This method could also be exempted with the `noratelimit` user right~~
* ~~the best option here is actually probably set a session value, and a hidden field, on submit check if session == field which checks for duplicate submissions~~

This is now fixed, it now only prevents submission of exact same comment as the last request in the current session.