### PR TITLE
Fix failing session tests on MediaWiki 1.44

### DIFF
--- a/.github/workflows/mediawiki-tests.yml
+++ b/.github/workflows/mediawiki-tests.yml
@@ -18,7 +18,7 @@ jobs:
             php-docker: 81
             composer-test: true
             coverage: true
-            experimental: false
+            experimental: true
 
           # Latest MediaWiki beta - PHP 8.1
           - mw: 'REL1_44'

--- a/tests/phpunit/Specials/SpecialRequestImportTest.php
+++ b/tests/phpunit/Specials/SpecialRequestImportTest.php
@@ -105,11 +105,7 @@ class SpecialRequestImportTest extends SpecialPageTestBase {
 			$this->setSessionUser( $user, $user->getRequest() );
 		}
 
-		$request = new FauxRequest(
-			[ 'wpEditToken' => $user->getEditToken() ],
-			true
-		);
-
+		$request = new FauxRequest( [], true );
 		$request->setUpload( 'wpUploadFile', [
 			'name' => basename( $formData['UploadFile'] ),
 			'type' => $extraData['mime-type'],

--- a/tests/phpunit/Specials/SpecialRequestImportTest.php
+++ b/tests/phpunit/Specials/SpecialRequestImportTest.php
@@ -105,7 +105,11 @@ class SpecialRequestImportTest extends SpecialPageTestBase {
 			$this->setSessionUser( $user, $user->getRequest() );
 		}
 
-		$request = new FauxRequest( [], true );
+		$request = new FauxRequest(
+			[], true,
+			RequestContext::getMain()->getRequest()->getSession()
+		);
+
 		$request->setUpload( 'wpUploadFile', [
 			'name' => basename( $formData['UploadFile'] ),
 			'type' => $extraData['mime-type'],


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Updated a test to improve session handling in the simulated request.
  - Enabled experimental features in the test configuration for PHP 8.1 on the stable release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->