### PR TITLE
allow manually setting status to in progress when automated jobs are enabled

### DIFF
--- a/includes/ImportDumpRequestViewer.php
+++ b/includes/ImportDumpRequestViewer.php
@@ -346,6 +346,7 @@ class ImportDumpRequestViewer implements ImportDumpStatus {
 						'options-messages' => array_unique( [
 							'importdump-label-' . $status => $status,
 							'importdump-label-pending' => self::STATUS_PENDING,
+							'importdump-label-inprogress' => self::STATUS_INPROGRESS,
 							'importdump-label-complete' => self::STATUS_COMPLETE,
 						] ),
 						'default' => $status,


### PR DESCRIPTION
It's good to still be able to set the In progress status manually if something happens, and an import needs to be run manually.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added "inprogress" as a selectable status option when updating the status of an import dump request in the form UI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->