### PR TITLE
Remove escape()

### DIFF
--- a/includes/ImportDumpRequestQueuePager.php
+++ b/includes/ImportDumpRequestQueuePager.php
@@ -36,19 +36,19 @@ class ImportDumpRequestQueuePager extends TablePager
 	}
 
 	/** @inheritDoc */
-	public function formatValue( $field, $value ): string {
+	public function formatValue( $name, $value ): string {
 		if ( $value === null ) {
 			return '';
 		}
 
-		switch ( $field ) {
+		switch ( $name ) {
 			case 'request_timestamp':
-				$formatted = $this->escape( $this->getLanguage()->userTimeAndDate(
+				$formatted = htmlspecialchars( $this->getLanguage()->userTimeAndDate(
 					$value, $this->getUser()
 				) );
 				break;
 			case 'request_target':
-				$formatted = $this->escape( $value );
+				$formatted = htmlspecialchars( $value );
 				break;
 			case 'request_status':
 				$row = $this->getCurrentRow();
@@ -59,20 +59,13 @@ class ImportDumpRequestQueuePager extends TablePager
 				break;
 			case 'request_actor':
 				$user = $this->userFactory->newFromActorId( (int)$value );
-				$formatted = $this->escape( $user->getName() );
+				$formatted = htmlspecialchars( $user->getName() );
 				break;
 			default:
-				$formatted = $this->escape( "Unable to format $field" );
+				$formatted = "Unable to format $name";
 		}
 
 		return $formatted;
-	}
-
-	/**
-	 * Safely HTML-escapes $value
-	 */
-	private function escape( string $value ): string {
-		return htmlspecialchars( $value, ENT_QUOTES );
 	}
 
 	/** @inheritDoc */


### PR DESCRIPTION
Now that we require PHP 8.2 we can just use htmlspecialchars directly and don't need ENT_QUOTES.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Standardized internal value-formatting parameters for greater consistency.
  - Unified output escaping for request details to ensure safer, consistent rendering.
  - Updated default fallback message text for formatting failures.
- Chores
  - Removed obsolete internal helper no longer in use.

No user-facing behavior changes; functionality and status/link rendering remain the same.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->