### PR TITLE
Allow deserializing ScalarParams in log entries

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -107,6 +107,32 @@
 			]
 		}
 	},
+	"LogParamsAllowedClasses": {
+		"importdump/interwiki": [
+			"Wikimedia\\Message\\ScalarParam"
+		],
+		"importdump/request": [
+			"Wikimedia\\Message\\ScalarParam"
+		],
+		"importdump/started": [
+			"Wikimedia\\Message\\ScalarParam"
+		],
+		"importdump/statusupdate": [
+			"Wikimedia\\Message\\ScalarParam"
+		],
+		"importdumpprivate/interwiki": [
+			"Wikimedia\\Message\\ScalarParam"
+		],
+		"importdumpprivate/request": [
+			"Wikimedia\\Message\\ScalarParam"
+		],
+		"importdumpprivate/started": [
+			"Wikimedia\\Message\\ScalarParam"
+		],
+		"importdumpprivate/statusupdate": [
+			"Wikimedia\\Message\\ScalarParam"
+		]
+	},
 	"SpecialPages": {
 		"RequestImport": {
 			"class": "Miraheze\\ImportDump\\Specials\\SpecialRequestImport",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced import-dump logging to accept scalar message parameters across interwiki, request, startup, and status-update events.
  * Improved consistency of parameter handling for both public and private logging actions.
  * Existing import-dump workflows remain compatible while providing more flexible event information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->